### PR TITLE
CGT-711: Created allowable losses basic HTML content

### DIFF
--- a/app/views/calculation/allowableLosses.scala.html
+++ b/app/views/calculation/allowableLosses.scala.html
@@ -1,10 +1,30 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>Title</title>
-</head>
-<body>
+@()(implicit request: Request[_])
 
-</body>
-</html>
+@import views.html.helpers._
+
+@hiddenYesNoContent = {
+    @simpleInputMoney("allowableLosses", Messages("calc.allowableLosses.question.two"))
+}
+
+@hiddenHelpTextContent = {
+    <p>@Messages("calc.allowableLosses.helpText.paragraph.one")</p>
+    <ul class="list list-bullet">
+        <li>@Messages("calc.allowableLosses.helpText.bullet.one")</li>
+        <li>@Messages("calc.allowableLosses.helpText.bullet.two")</li>
+        <li>@Messages("calc.allowableLosses.helpText.bullet.three")</li>
+    </ul>
+}
+
+@main_template(Messages("calc.allowableLosses.question.one")) {
+
+    <a id="link-back" class="link-back" href="@routes.CalculationController.entrepreneursRelief">Back</a>
+
+    <h1 class="heading-large">@Messages("calc.base.pageHeading")</h1>
+
+    @hiddenYesNoRadio("allowableLosses",Messages("calc.allowableLosses.question.one"),hiddenYesNoContent)
+
+    @hiddenHelpText("allowableLossesHiddenHelp",Messages("calc.allowableLosses.helpText.title"),hiddenHelpTextContent)
+
+    <button class="button" type="submit" id="continue-button">@Messages("calc.base.continue")</button>
+
+}

--- a/app/views/helpers/hiddenHelpText.scala.html
+++ b/app/views/helpers/hiddenHelpText.scala.html
@@ -1,0 +1,10 @@
+@(helpTextId: String, helpTextTitle: String, content: Html)
+
+<div id="@helpTextId" class="form-group">
+    <details>
+        <summary><span class="summary">@helpTextTitle</span></summary>
+        <div class="panel panel-border-narrow">
+            @content
+        </div>
+    </details>
+</div>

--- a/app/views/helpers/hiddenYesNoRadio.scala.html
+++ b/app/views/helpers/hiddenYesNoRadio.scala.html
@@ -1,7 +1,7 @@
-@(fieldName: String, questionText:String, content:String, helpText:Option[String] = None)(implicit lang: play.api.i18n.Lang)
+@(fieldName: String, questionText:String, content:Html, helpText:Option[String] = None)(implicit lang: play.api.i18n.Lang)
 
 <fieldset class="form-group" data-hidden='hidden'>
-    <label>@questionText</label>
+    <legend>@questionText</legend>
     @if(helpText.isDefined) { <span class="form-hint">@helpText.get</span> }
 
     <div class="inline">
@@ -15,6 +15,6 @@
         </label>
     </div>
     <div class="panel-indent" id='hidden'>
-        @Html(content)
+        @content
     </div>
 </fieldset>

--- a/app/views/helpers/simpleInputMoney.scala.html
+++ b/app/views/helpers/simpleInputMoney.scala.html
@@ -1,7 +1,7 @@
 @(fieldName: String, questionText: String, helpText: Option[String] = None)(implicit lang: play.api.i18n.Lang)
 
-<fieldset class="form-group">
-    <legend>@questionText</legend>
+<div class="form-group">
+    <label for="@fieldName">@questionText</label>
     @if(helpText.isDefined) { <span class="form-hint">@helpText</span> }
     <input class="form-control" id="@fieldName" type="text" placeholder="£">
-</fieldset>
+</div>

--- a/conf/messages
+++ b/conf/messages
@@ -88,7 +88,14 @@ calc.disposalCosts.title = How much did you pay in costs when you stopped being 
 calc.entrepreneursRelief.title = Are you claiming Entrepreneurs' Relief?
 
 ## Allowable Losses ##
-calc.allowableLosses.title = Are you claiming any allowable losses?
+calc.allowableLosses.question.one = Are you claiming any allowable losses?
+calc.allowableLosses.question.two = What's the total value of your allowable losses?
+calc.allowableLosses.helpText.title = What are allowable losses?
+calc.allowableLosses.helpText.paragraph.one = They''re losses you''ve made on UK properties that:
+calc.allowableLosses.helpText.bullet.one = are covered by Capital Gains Tax
+calc.allowableLosses.helpText.bullet.two = you''ve declared to HMRC within four years of making the loss
+calc.allowableLosses.helpText.bullet.three = you haven't already used in an allowable losses claim
+
 
 ## Other Reliefs ##
 calc.otherReliefs.title = How much extra tax relief are you claiming?

--- a/test/controllers/CalculationControllerSpec.scala
+++ b/test/controllers/CalculationControllerSpec.scala
@@ -209,7 +209,7 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication {
       "display the correct question heading" in new fakeRequestTo("allowance") {
         val result = CalculationController.annualExemptAmount(fakeRequest)
         val jsoupDoc = Jsoup.parse(bodyOf(result))
-        jsoupDoc.body.getElementsByTag("legend").text shouldEqual Messages("calc.annualExemptAmount.question")
+        jsoupDoc.body.getElementsByTag("label").text shouldEqual Messages("calc.annualExemptAmount.question")
       }
 
       "Have an input box for the Annual Exempt Amount" in new fakeRequestTo("allowance") {
@@ -307,7 +307,7 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication {
     "contain the question How much did you sell or give away the property for?" in new fakeRequestTo("disposal-value") {
       val result = CalculationController.disposalValue(fakeRequest)
       val jsoupDoc = Jsoup.parse(bodyOf(result))
-      jsoupDoc.select("legend").text shouldEqual Messages("calc.disposalValue.title")
+      jsoupDoc.select("label").text shouldEqual Messages("calc.disposalValue.title")
     }
 
     "contain a button with id equal to continue in disposal-value" in new fakeRequestTo("disposal-date") {
@@ -352,17 +352,73 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication {
       charset(result) shouldBe Some("utf-8")
     }
 
+
     //################### Allowable Losses tests #######################
-    "return 200 when sending a GET request `/calculate-your-capital-gains/allowable-losses`" in new fakeRequestTo("allowable-losses") {
-      val result = CalculationController.allowableLosses(fakeRequest)
-      status(result) shouldBe 200
+    "When calling the allowableLosses action" should {
+
+      "return 200" in new fakeRequestTo("allowable-losses") {
+        val result = CalculationController.allowableLosses(fakeRequest)
+        status(result) shouldBe 200
+      }
+
+      "return HTML" in new fakeRequestTo("allowable-losses") {
+        val result = CalculationController.allowableLosses(fakeRequest)
+        contentType(result) shouldBe Some("text/html")
+        charset(result) shouldBe Some("utf-8")
+      }
+
+      "have a back button" in new fakeRequestTo("allowable-losses") {
+        val result = CalculationController.allowableLosses(fakeRequest)
+        val jsoupDoc = Jsoup.parse(bodyOf(result))
+        jsoupDoc.body.getElementById("link-back").text shouldEqual Messages("calc.base.back")
+      }
+
+      "display the correct title" in new fakeRequestTo("allowable-losses") {
+        val result = CalculationController.allowableLosses(fakeRequest)
+        val jsoupDoc = Jsoup.parse(bodyOf(result))
+        jsoupDoc.title shouldEqual Messages("calc.allowableLosses.question.one")
+      }
+
+      "display the correct heading" in new fakeRequestTo("allowable-losses") {
+        val result = CalculationController.allowableLosses(fakeRequest)
+        val jsoupDoc = Jsoup.parse(bodyOf(result))
+        jsoupDoc.body.getElementsByTag("H1").text shouldEqual Messages("calc.base.pageHeading")
+      }
+
+      "display hidden Yes No Radio helper" in new fakeRequestTo("allowable-losses") {
+        val result = CalculationController.allowableLosses(fakeRequest)
+        val jsoupDoc = Jsoup.parse(bodyOf(result))
+        jsoupDoc.body.getElementById("allowableLossesYes").parent.text shouldBe Messages("calc.base.yes")
+        jsoupDoc.body.getElementById("allowableLossesNo").parent.text shouldBe Messages("calc.base.no")
+        jsoupDoc.body.getElementsByTag("legend").text shouldBe Messages("calc.allowableLosses.question.one")
+      }
+
+      "Display a monetary input box for the allowable losses with correct question" in new fakeRequestTo("allowable-losses") {
+        val result = CalculationController.allowableLosses(fakeRequest)
+        val jsoupDoc = Jsoup.parse(bodyOf(result))
+        jsoupDoc.body.getElementById("allowableLosses").tagName shouldEqual "input"
+        jsoupDoc.select("label[for=allowableLosses]").text shouldEqual Messages("calc.allowableLosses.question.two")
+      }
+
+      "have a hidden help text section with correct title and content" in new fakeRequestTo("allowable-losses") {
+        val result = CalculationController.allowableLosses(fakeRequest)
+        val jsoupDoc = Jsoup.parse(bodyOf(result))
+        jsoupDoc.select("div#allowableLossesHiddenHelp").text should
+          include (Messages("calc.allowableLosses.helpText.title"))
+          include (Messages("calc.allowableLosses.helpText.paragraph.one"))
+          include (Messages("calc.allowableLosses.helpText.bullet.one"))
+          include (Messages("calc.allowableLosses.helpText.bullet.two"))
+          include (Messages("calc.allowableLosses.helpText.bullet.three"))
+      }
+
+      "has a Continue button" in new fakeRequestTo("allowable-losses") {
+        val result = CalculationController.allowableLosses(fakeRequest)
+        val jsoupDoc = Jsoup.parse(bodyOf(result))
+        jsoupDoc.body.getElementById("continue-button").text shouldEqual Messages("calc.base.continue")
+      }
     }
 
-    "return HTML when sending a GET to `/calculate-your-capital-gains/allowable-losses`" in new fakeRequestTo("allowable-losses"){
-      val result = CalculationController.allowableLosses(fakeRequest)
-      contentType(result) shouldBe Some("text/html")
-      charset(result) shouldBe Some("utf-8")
-    }
+
 
     //################### Other Reliefs tests #######################
     "return 200 when sending a GET request `/calculate-your-capital-gains/other-reliefs`" in new fakeRequestTo("other-reliefs") {


### PR DESCRIPTION
Also created a helper called **hiddenHelpText** for the hidden/dropdown help text so that this can be used on future pages which need it.

In addition, I have amended:

**hiddenYesNoRadio helper**
Changed to use a `<legend>` rather than a `<label>` as a legend is required for fieldsets (based on standards/comments in the GDS patterns).

Changed the content parameter to be type HTML, i.e. `content: Html` as I was having to convert HTML to a string before converting it back to HTML, which seemed long winded and backwards. So it was far better to just pass the content directly as HTML.

**simpleInputMoney**
Changed this to use a `<div>` rather than a `<fieldset>` as there isn't a set of fields in this case. It's just a single input so can be wrapped in a div. This meant that the `<legend>` can be changed to a `<label>` that maps to the input field (using the `for` meta-data tag) and thus aids accessibility.

For the two changes above, I have amended the scala tests to use the appropriate tag to identify the content.