### PR TITLE
CGT-807: Created Acquisition costs basic HTML content

### DIFF
--- a/app/views/calculation/acquisitionCosts.scala.html
+++ b/app/views/calculation/acquisitionCosts.scala.html
@@ -4,4 +4,6 @@
 
     <a id="link-back" class="link-back" href="#">@Messages("calc.base.back")</a>
 
+    <h1 class="heading-large">@Messages("calc.base.pageHeading")</h1>
+
 }

--- a/app/views/calculation/acquisitionCosts.scala.html
+++ b/app/views/calculation/acquisitionCosts.scala.html
@@ -10,6 +10,6 @@
 
     @simpleInputMoney("acquisitionCosts",Messages("calc.acquisitionCosts.question"),Some(Messages("calc.acquisitionCosts.helpText")))
 
-
+    <button class="button" type="submit" id="continue-button">@Messages("calc.base.continue")</button>
 
 }

--- a/app/views/calculation/acquisitionCosts.scala.html
+++ b/app/views/calculation/acquisitionCosts.scala.html
@@ -1,10 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>Title</title>
-</head>
-<body>
+@()(implicit request: Request[_])
 
-</body>
-</html>
+@main_template(Messages("calc.acquisitionCosts.question")) {
+
+}

--- a/app/views/calculation/acquisitionCosts.scala.html
+++ b/app/views/calculation/acquisitionCosts.scala.html
@@ -1,9 +1,15 @@
 @()(implicit request: Request[_])
 
+@import views.html.helpers._
+
 @main_template(Messages("calc.acquisitionCosts.question")) {
 
     <a id="link-back" class="link-back" href="#">@Messages("calc.base.back")</a>
 
     <h1 class="heading-large">@Messages("calc.base.pageHeading")</h1>
+
+    @simpleInputMoney("acquisitionCosts",Messages("calc.acquisitionCosts.question"),Some(Messages("calc.acquisitionCosts.helpText")))
+
+
 
 }

--- a/app/views/calculation/acquisitionCosts.scala.html
+++ b/app/views/calculation/acquisitionCosts.scala.html
@@ -2,4 +2,6 @@
 
 @main_template(Messages("calc.acquisitionCosts.question")) {
 
+    <a id="link-back" class="link-back" href="#">@Messages("calc.base.back")</a>
+
 }

--- a/app/views/calculation/disposalCosts.scala.html
+++ b/app/views/calculation/disposalCosts.scala.html
@@ -8,7 +8,7 @@
 
     <h1 class="heading-large">@Messages("calc.base.pageHeading")</h1>
 
-    @simpleInputMoney("disposalCosts",Messages("calc.disposalCosts.question"),Some(Messages("calc.disposalCosts.helpText")))
+    @simpleInputMoney("disposalCosts",Messages("calc.disposalCosts.question"))
 
     <button class="button" type="submit" id="continue-button">@Messages("calc.base.continue")</button>
 

--- a/conf/messages
+++ b/conf/messages
@@ -79,10 +79,10 @@ calc.disposalValue.question = How much did you sell or give away the property fo
 
 ## Acquisition Costs ##
 calc.acquisitionCosts.question = How much did you pay in costs when you became the property owner?
+calc.acquisitionCosts.helpText = Costs include agent fees, legal fees and surveys
 
 ## Disposal Costs ##
 calc.disposalCosts.question = How much did you pay in costs when you stopped being the property owner?
-calc.disposalCosts.helpText = Costs include agent fees, legal fees and surveys
 
 ## Entrepreneurs Relief ##
 calc.entrepreneursRelief.question = Are you claiming Entrepreneurs' Relief?

--- a/test/controllers/CalculationControllerSpec.scala
+++ b/test/controllers/CalculationControllerSpec.scala
@@ -430,6 +430,17 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication {
             AcquisitionCostsTestDataItem.jsoupDoc.getElementById("acquisitionCosts").tagName shouldBe "input"
           }
         }
+
+        "have a continue button that" should {
+
+          "be a button element" in {
+            AcquisitionCostsTestDataItem.jsoupDoc.getElementById("continue-button").tagName shouldBe "button"
+          }
+
+          "have the text 'Continue'" in {
+            AcquisitionCostsTestDataItem.jsoupDoc.getElementById("continue-button").text shouldEqual Messages("calc.base.continue")
+          }
+        }
       }
     }
 

--- a/test/controllers/CalculationControllerSpec.scala
+++ b/test/controllers/CalculationControllerSpec.scala
@@ -407,6 +407,10 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication {
         "have the title 'How much did you pay in costs when you became the property owner'" in {
           AcquisitionCostsTestDataItem.jsoupDoc.getElementsByTag("title").text shouldEqual Messages("calc.acquisitionCosts.question")
         }
+
+        "have a back link" in {
+          AcquisitionCostsTestDataItem.jsoupDoc.getElementById("link-back").text shouldEqual Messages("calc.base.back")
+        }
       }
     }
 

--- a/test/controllers/CalculationControllerSpec.scala
+++ b/test/controllers/CalculationControllerSpec.scala
@@ -416,7 +416,20 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication {
           AcquisitionCostsTestDataItem.jsoupDoc.getElementsByTag("h1").text shouldEqual Messages("calc.base.pageHeading")
         }
 
+        "have a monetary field that" should {
 
+          "have the title 'How much did you pay in costs when you became the property owner?'" in {
+            AcquisitionCostsTestDataItem.jsoupDoc.select("label[for=acquisitionCosts]").text shouldEqual Messages("calc.acquisitionCosts.question")
+          }
+
+          "have the help text 'Costs include agent fees, legal fees and surveys'" in {
+            AcquisitionCostsTestDataItem.jsoupDoc.select("span.form-hint").text shouldEqual Messages("calc.acquisitionCosts.helpText")
+          }
+
+          "have an input box for the acquisition costs" in {
+            AcquisitionCostsTestDataItem.jsoupDoc.getElementById("acquisitionCosts").tagName shouldBe "input"
+          }
+        }
       }
     }
 
@@ -452,10 +465,6 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication {
 
           "have the title 'How much did you pay in costs when you became the property owner?'" in {
             DisposalCostsTestDataItem.jsoupDoc.select("label[for=disposalCosts]").text shouldEqual Messages("calc.disposalCosts.question")
-          }
-
-          "have the help text 'Costs include agent fees, legal fees and surveys'" in {
-            DisposalCostsTestDataItem.jsoupDoc.select("span.form-hint").text shouldEqual Messages("calc.disposalCosts.helpText")
           }
 
           "have an input box for the disposal costs" in {

--- a/test/controllers/CalculationControllerSpec.scala
+++ b/test/controllers/CalculationControllerSpec.scala
@@ -411,6 +411,12 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication {
         "have a back link" in {
           AcquisitionCostsTestDataItem.jsoupDoc.getElementById("link-back").text shouldEqual Messages("calc.base.back")
         }
+
+        "have the page heading 'Calculate your tax (non-residents)'" in {
+          AcquisitionCostsTestDataItem.jsoupDoc.getElementsByTag("h1").text shouldEqual Messages("calc.base.pageHeading")
+        }
+
+
       }
     }
 

--- a/test/controllers/CalculationControllerSpec.scala
+++ b/test/controllers/CalculationControllerSpec.scala
@@ -403,6 +403,10 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication {
           contentType(AcquisitionCostsTestDataItem.result) shouldBe Some("text/html")
           charset(AcquisitionCostsTestDataItem.result) shouldBe Some("utf-8")
         }
+
+        "have the title 'How much did you pay in costs when you became the property owner'" in {
+          AcquisitionCostsTestDataItem.jsoupDoc.getElementsByTag("title").text shouldEqual Messages("calc.acquisitionCosts.question")
+        }
       }
     }
 


### PR DESCRIPTION
**Note**
This change includes a small fix to the Disposal Costs page. It had help text, but in the prototype the help text is only on the acquisition costs page. Therefore, for now, it has been removed - associated scalatest removed as well.