### PR TITLE
CGT-783: Created scalatests and basic HTML content for Summary

### DIFF
--- a/app/views/calculation/summary.scala.html
+++ b/app/views/calculation/summary.scala.html
@@ -1,10 +1,134 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>Title</title>
-</head>
-<body>
+@()(implicit request: Request[_])
 
-</body>
-</html>
+@import views.html.helpers._
+
+@main_template(Messages("calc.summary.title"), articleLayout = false) {
+
+    <a id="back-link" class="back-link" href="#">@Messages("calc.base.back")</a>
+
+    @*
+    *  Calculated Tax Owed
+    *@
+    <div>
+        <h1 class="heading-xlarge heading-xxlarge">
+            <span class="heading-secondary">@Messages("calc.summary.secondaryHeading")</span>
+            <b>&pound;NNNN.pp</b>
+        </h1>
+    </div>
+
+     @*
+     *  Calculation Details Section
+     *@
+     @summaryPageSection("calcDetails",Messages("calc.summary.calculation.details.title"),
+        Array(
+            Map(
+                "question" -> Messages("calc.summary.calculation.details.totalGain"),
+                "answer" -> ""),
+            Map(
+                "question" -> Messages("calc.summary.calculation.details.taxableGain"),
+                "answer" -> ""),
+            Map(
+                "question" -> Messages("calc.summary.calculation.details.taxRate"),
+                "answer" -> "")
+        )
+    )
+
+
+    @*
+    *  Personal Details Section
+    *@
+    @summaryPageSection("personalDetails",Messages("calc.summary.personal.details.title"),
+        Array(
+            Map(
+                "question" -> Messages("calc.customerType.question"),
+                "answer" -> ""),
+            Map(
+                "question" -> Messages("calc.disabledTrustee.question"),
+                "answer" -> ""),
+            Map(
+                "question" -> Messages("calc.annualExemptAmount.question"),
+                "answer" -> "")
+        )
+    )
+
+
+    @*
+    *  Purchase Details Section
+    *@
+    @summaryPageSection("purchaseDetails",Messages("calc.summary.purchase.details.title"),
+        Array(
+            Map(
+                "question" -> Messages("calc.acquisitionValue.question"),
+                "answer" -> ""),
+            Map(
+                "question" -> Messages("calc.acquisitionCosts.question"),
+                "answer" -> "")
+        )
+    )
+
+
+    @*
+    *  Property Details Section
+    *@
+    @summaryPageSection("propertyDetails",Messages("calc.summary.property.details.title"),
+        Array(
+            Map(
+                "question" -> Messages("calc.improvements.question"),
+                "answer" -> "")
+        )
+    )
+
+
+    @*
+    *  Sale Details Section
+    *@
+    @summaryPageSection("saleDetails",Messages("calc.summary.sale.details.title"),
+        Array(
+            Map(
+                "question" -> Messages("calc.disposalDate.question"),
+                "answer" -> ""),
+            Map(
+                "question" -> Messages("calc.disposalValue.question"),
+                "answer" -> ""),
+            Map(
+                "question" -> Messages("calc.disposalCosts.question"),
+                "answer" -> "")
+        )
+    )
+
+
+    @*
+    *  Deductions Section
+    *@
+    @summaryPageSection("deductions",Messages("calc.summary.deductions.title"),
+        Array(
+            Map(
+                "question" -> Messages("calc.entrepreneursRelief.question"),
+                "answer" -> ""),
+            Map(
+                "question" -> Messages("calc.allowableLosses.question.two"),
+                "answer" -> "")
+        )
+    )
+
+
+    <div class="grid-layout__column grid-layout__column--2-3">
+
+        @*
+        *  What to do next
+        *@
+        <div id="whatToDoNext" class="form-group">
+            <h2 class="heading-medium">@Messages("calc.common.next.actions.heading")</h2>
+            <p>
+                @Messages("calc.summary.next.actions.text")
+                <a class="external-link" rel="external" href="#">@Messages("calc.summary.next.actions.link")</a>
+            </p>
+        </div>
+
+        @*
+        *  Start Again
+        *@
+        <a id="startAgain" class="bold-medium" href="@routes.IntroductionController.introduction">@Messages("calc.summary.startAgain")</a>
+
+    </div>
+}

--- a/app/views/helpers/summaryPageSection.scala.html
+++ b/app/views/helpers/summaryPageSection.scala.html
@@ -1,0 +1,17 @@
+@(sectionId: String, sectionTitle: String, sectionContent: Array[Map[String,String]])
+
+<section id="@sectionId">
+    @for(i <- 0 until sectionContent.length) {
+        <div class="grid-layout grid-layout--stacked form-group">
+            <div class="grid-layout__column grid-layout__column--1-3">
+                @if(i==0){<span class="heading-large">@sectionTitle</span>}
+            </div>
+            <div class="grid-layout__column grid-layout__column--1-3">
+                <span class="lede">@sectionContent(i)("question")</span>
+            </div>
+            <div class="grid-layout__column grid-layout__column--1-3">
+                <span class="lede">@Html(sectionContent(i)("answer"))</span>
+            </div>
+        </div>
+    }
+</section>

--- a/app/views/main_template.scala.html
+++ b/app/views/main_template.scala.html
@@ -4,7 +4,8 @@
   contentHeader: Option[Html] = None,
   bodyClasses: Option[String] = None,
   mainClass: Option[String] = None,
-  scriptElem: Option[Html] = None)(mainContent: Html)(implicit request : Request[_])
+  scriptElem: Option[Html] = None,
+  articleLayout: Boolean = true)(mainContent: Html)(implicit request : Request[_])
 
 @import uk.gov.hmrc.play.views.html.layouts
 
@@ -21,13 +22,21 @@
     }
 }
 
+@contentLayout = {
+    @if(articleLayout) {
+        @layouts.article(mainContent)
+    } else {
+        @mainContent
+    }
+}
+
 @govuk_wrapper(appConfig = ApplicationConfig,
                title = title,
                mainClass = mainClass,
                bodyClasses = bodyClasses,
                sidebar = sidebar,
                contentHeader = contentHeader,
-               mainContent = layouts.article(mainContent),
+               mainContent = contentLayout,
                serviceInfoContent = serviceInfoContent,
                scriptElem = scriptElem
 )

--- a/conf/messages
+++ b/conf/messages
@@ -17,6 +17,7 @@ calc.common.date.fields.month = Month
 calc.common.date.fields.year = Year
 calc.common.date.hint = For example, 4 9 2016
 calc.common.readMore = Read more
+calc.common.next.actions.heading = What to do next
 
 ## Introduction ##
 calc.introduction.title = Introduction
@@ -104,5 +105,24 @@ calc.otherReliefs.question = How much extra tax relief are you claiming?
 
 ## Summary ##
 calc.summary.title = Summary
+calc.summary.secondaryHeading = You owe
+calc.summary.calculation.details.title = Calculation details
+calc.summary.calculation.details.totalGain = Your total gain
+calc.summary.calculation.details.taxableGain = Your taxable gain
+calc.summary.calculation.details.taxRate = Your tax rate
+calc.summary.personal.details.title = Personal details
+calc.summary.purchase.details.title = Purchase details
+calc.summary.property.details.title = Property details
+calc.summary.sale.details.title = Sale details
+calc.summary.deductions.title = Deductions
+calc.summary.next.actions.text = You need to
+calc.summary.next.actions.link = tell HMRC about the property
+calc.summary.startAgain = Start again
+
+
+
+
+
+
 
 

--- a/test/controllers/CalculationControllerSpec.scala
+++ b/test/controllers/CalculationControllerSpec.scala
@@ -672,6 +672,137 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication {
           contentType(SummaryTestDataItem.result) shouldBe Some("text/html")
           charset(SummaryTestDataItem.result) shouldBe Some("utf-8")
         }
+
+        "should have the title 'Summary'" in {
+          SummaryTestDataItem.jsoupDoc.getElementsByTag("title").text shouldEqual Messages("calc.summary.title")
+        }
+
+        "have a back button" in {
+          SummaryTestDataItem.jsoupDoc.getElementById("back-link").text shouldEqual Messages("calc.base.back")
+        }
+
+        "have the correct sub-heading 'You owe'" in {
+          SummaryTestDataItem.jsoupDoc.select("h1 span").text shouldEqual Messages("calc.summary.secondaryHeading")
+        }
+
+        "have a result amount currently set to £NNNN.pp" in {
+          SummaryTestDataItem.jsoupDoc.select("h1 b").text shouldEqual "£NNNN.pp"
+        }
+
+        "have a 'Calculation details' section that" should {
+
+          "include the section heading 'Calculation details" in {
+            SummaryTestDataItem.jsoupDoc.select("#calcDetails").text should include (Messages("calc.summary.calculation.details.title"))
+          }
+
+          "include 'Your total gain'" in {
+            SummaryTestDataItem.jsoupDoc.select("#calcDetails").text should include (Messages("calc.summary.calculation.details.totalGain"))
+          }
+
+          "include 'Your taxable gain'" in {
+            SummaryTestDataItem.jsoupDoc.select("#calcDetails").text should include (Messages("calc.summary.calculation.details.taxableGain"))
+          }
+
+          "include 'Your tax rate'" in {
+            SummaryTestDataItem.jsoupDoc.select("#calcDetails").text should include (Messages("calc.summary.calculation.details.taxRate"))
+          }
+        }
+
+        "have a 'Personal details' section that" should {
+
+          "include the section heading 'Personal details" in {
+            SummaryTestDataItem.jsoupDoc.select("#personalDetails").text should include (Messages("calc.summary.personal.details.title"))
+          }
+
+          "include the question 'Who owned the property?'" in {
+            SummaryTestDataItem.jsoupDoc.select("#personalDetails").text should include (Messages("calc.customerType.question"))
+          }
+
+          "include the question 'Are you a trustee for someone who's vulnerable'" in {
+            SummaryTestDataItem.jsoupDoc.select("#personalDetails").text should include (Messages("calc.disabledTrustee.question"))
+          }
+
+          "include the question 'How much of your Capital Gains Tax allowance have you got left'" in {
+            SummaryTestDataItem.jsoupDoc.select("#personalDetails").text should include (Messages("calc.annualExemptAmount.question"))
+          }
+        }
+
+        "have a 'Purchase details' section that" should {
+
+          "include the section heading 'Purchase details" in {
+            SummaryTestDataItem.jsoupDoc.select("#purchaseDetails").text should include (Messages("calc.summary.purchase.details.title"))
+          }
+
+          "include the question 'How much did you pay for the property?'" in {
+            SummaryTestDataItem.jsoupDoc.select("#purchaseDetails").text should include (Messages("calc.acquisitionValue.question"))
+          }
+
+          "include the question 'How much did you pay in costs when you became the property owner?'" in {
+            SummaryTestDataItem.jsoupDoc.select("#purchaseDetails").text should include (Messages("calc.acquisitionCosts.question"))
+          }
+        }
+
+        "have a 'Property details' section that" should {
+
+          "include the section heading 'Property details" in {
+            SummaryTestDataItem.jsoupDoc.select("#propertyDetails").text should include (Messages("calc.summary.property.details.title"))
+          }
+
+          "include the question 'How much did you pay for the property?'" in {
+            SummaryTestDataItem.jsoupDoc.select("#propertyDetails").text should include (Messages("calc.improvements.question"))
+          }
+        }
+
+        "have a 'Sale details' section that" should {
+
+          "include the section heading 'Sale details" in {
+            SummaryTestDataItem.jsoupDoc.select("#saleDetails").text should include (Messages("calc.summary.sale.details.title"))
+          }
+
+          "include the question 'When did you sign the contract that made someone else the owner?'" in {
+            SummaryTestDataItem.jsoupDoc.select("#saleDetails").text should include (Messages("calc.disposalDate.question"))
+          }
+
+          "include the question 'How much did you sell or give away the property for?'" in {
+            SummaryTestDataItem.jsoupDoc.select("#saleDetails").text should include (Messages("calc.disposalValue.question"))
+          }
+
+          "include the question 'How much did you pay in costs when you stopped being the property owner?'" in {
+            SummaryTestDataItem.jsoupDoc.select("#saleDetails").text should include (Messages("calc.disposalCosts.question"))
+          }
+        }
+
+        "have a 'Deductions details' section that" should {
+
+          "include the section heading 'Deductions" in {
+            SummaryTestDataItem.jsoupDoc.select("#deductions").text should include (Messages("calc.summary.deductions.title"))
+          }
+
+          "include the question 'Are you claiming Entrepreneurs' Relief?'" in {
+            SummaryTestDataItem.jsoupDoc.select("#deductions").text should include (Messages("calc.entrepreneursRelief.question"))
+          }
+
+          "include the question 'Whats the total value of your allowable losses?'" in {
+            SummaryTestDataItem.jsoupDoc.select("#deductions").text should include (Messages("calc.allowableLosses.question.two"))
+          }
+        }
+
+        "have a 'What to do next' section that" should {
+
+          "have the heading 'What to do next'" in {
+            SummaryTestDataItem.jsoupDoc.select("#whatToDoNext H2").text shouldEqual (Messages("calc.common.next.actions.heading"))
+          }
+
+          "include the text 'You need to tell HMRC about the property'" in {
+            SummaryTestDataItem.jsoupDoc.select("#whatToDoNext").text should
+              include (Messages("calc.summary.next.actions.text"))
+              include (Messages("calc.summary.next.actions.link"))
+          }
+        }
+
+        "have a link to 'Start again'" in {
+          SummaryTestDataItem.jsoupDoc.select("#startAgain").text shouldEqual Messages("calc.summary.startAgain")
+        }
       }
     }
   }


### PR DESCRIPTION
**Note**
This page is very basic at the moment. It assumes that all the questions would be displayed on the page - and no answrs are presented as there is no form binding/model etc yet. 

Of course, in reality, this will be dynamically driven based on the answers the user has provided and the journey that they have been taken down. So there will be significant changes to this page in the future.

The main goal for this task was to get the basic structure in place.

**GovUK Wrapper Change**
A change was required so that the GovUK wrapper didn't always use the article() layout (which is 66% width of screen) - this is because the summary needs to be full page width (100%). A new parameter has been added to the wapper called `articleLayout` with the default set to `true`. 

It then interogates the boolean value to determine whether the content should be wrapped in an article layout (when true) or left unchanged (100%) if false.

On the Summary page the parameter value is set to false to enable the page content to be full width.

**Section Helper**
A new helper `summaryPageSection` was introduced to generate the the blocks of information displayed on the summary page. It accepts an Array of Map[String,String]. The map is built up as:

- 'question' -> Question from Messages File
- 'answer' -> Answer from Form/Model (to be done at a later date as part of a separate task)

These are then rendered in the correct format by the helper. Because it accepts an Array of Maps we can dynamically pass it the specific question and answers that we need to display based on the user journey.

**Scalatests**
At the moment, the tests are very basic and test that the content is displayed - these will need to be enhanced when we add in the form bindings, model etc.