### PR TITLE
CGT-709: Disabled trustee keystore form bindings

### DIFF
--- a/app/controllers/CalculationController.scala
+++ b/app/controllers/CalculationController.scala
@@ -17,8 +17,9 @@
 package controllers
 
 import connectors.CalculatorConnector
-import forms.CustomerTypeForm.customerTypeForm
-import models.CustomerTypeModel
+import forms.CustomerTypeForm._
+import forms.DisabledTrusteeForm._
+import models.{CustomerTypeModel,DisabledTrusteeModel}
 import play.api.mvc.Action
 import uk.gov.hmrc.play.frontend.controller.FrontendController
 
@@ -43,7 +44,10 @@ trait CalculationController extends FrontendController {
 
   //################### Disabled Trustee methods #######################
   val disabledTrustee = Action.async { implicit request =>
-    Future.successful(Ok(calculation.disabledTrustee()))
+    calcConnector.fetchAndGetFormData[DisabledTrusteeModel]("isVulnerable").map {
+      case Some(data) => Ok(calculation.disabledTrustee(disabledTrusteeForm.fill(data)))
+      case None => Ok(calculation.disabledTrustee(disabledTrusteeForm))
+    }
   }
 
   //################### Current Income methods #######################

--- a/app/forms/DisabledTrusteeForm.scala
+++ b/app/forms/DisabledTrusteeForm.scala
@@ -14,12 +14,17 @@
  * limitations under the License.
  */
 
-package models
+package forms
 
-import play.api.libs.json.Json
+import play.api.data._
+import play.api.data.Forms._
+import models._
+import play.api.data.format.Formats._
 
-case class DisabledTrusteeModel (isVulnerable: String)
-
-object DisabledTrusteeModel {
-  implicit val format = Json.format[DisabledTrusteeModel]
+object DisabledTrusteeForm {
+  val disabledTrusteeForm = Form(
+    mapping(
+      "isVulnerable" -> text
+    )(DisabledTrusteeModel.apply)(DisabledTrusteeModel.unapply)
+  )
 }

--- a/app/views/calculation/disabledTrustee.scala.html
+++ b/app/views/calculation/disabledTrustee.scala.html
@@ -1,5 +1,9 @@
-@()(implicit request: Request[_])
 @import views.html.helpers._
+@import models.DisabledTrusteeModel
+@import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
+@import play.api.data._
+
+@(disabledTrusteeForm: Form[DisabledTrusteeModel])(implicit request: Request[_])
 
 @main_template(Messages("calc.disabledTrustee.question")) {
 
@@ -7,8 +11,22 @@
 
     <h1 class="heading-large">@Messages("calc.base.pageHeading")</h1>
 
-    @simpleYesNoRadio("isVulnerable",Messages("calc.disabledTrustee.question"),Some(Messages("calc.disabledTrustee.helptext")))
+        @govHelpers.form(action = routes.CalculationController.disabledTrustee) {
 
-    <button class="button" type="submit" id="continue-button">@Messages("calc.base.continue")</button>
+        <div class="form-group">
+            @formInputRadioGroup(
+                field = disabledTrusteeForm("isVulnerable"),
+                Seq(
+                    "Yes"->Messages("calc.base.yes"),
+                    "No"->Messages("calc.base.no")),
+                '_legend -> Messages("calc.disabledTrustee.question"),
+                '_helpText -> Messages("calc.disabledTrustee.helptext"),
+                '_labelAfter -> true,
+                '_labelClass -> "block-label",
+                '_groupClass -> "inline"
+            )
+        </div>
 
+        <button class="button" type="submit" id="continue-button">@Messages("calc.base.continue")</button>
+    }
 }

--- a/app/views/helpers/formInputRadioGroup.scala.html
+++ b/app/views/helpers/formInputRadioGroup.scala.html
@@ -1,0 +1,73 @@
+@*
+* Copyright 2016 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
+@(field: Field, radioOptions: Seq[(String, String)], args: (Symbol, Any)*)(implicit lang: play.api.i18n.Lang)
+
+@import play.api.i18n._
+@import views.html.helper._
+
+@elements = @{new FieldElements(field.id, field, null, args.toMap, lang) }
+@fieldsetClass = {@elements.args.get('_groupClass)@if(elements.hasErrors){ form-field--error}}
+@labelAfter = @{ elements.args.get('_labelAfter).getOrElse(false).asInstanceOf[Boolean] }
+<fieldset class="@fieldsetClass"
+    @if(elements.args.get('_fieldsetAttributes).isDefined) {@elements.args.get('_fieldsetAttributes)}>
+    @if(elements.args.get('_legend).isDefined) {
+        <legend @if(elements.args.get('_legendClass).isDefined) {class="@elements.args.get('_legendClass)"}>
+            @elements.args.get('_legend)
+        </legend>
+    }
+    @if(elements.args.get('_helpText).isDefined) {
+        <span class="form-hint">
+            @elements.args.get('_helpText)
+        </span>
+    }
+    @elements.errors.map{error => <span class="error-notification">@Messages(error)</span>}
+
+    @radioOptions.map { case (value, label) =>
+        @defining(s"${elements.field.name}-${value.toLowerCase.replace(" ","_")}")  { inputId =>
+            <label for="@inputId"
+               @elements.args.get('_labelClass).map{labelClass => class="@labelClass@field.value.filter( _ == value).map{_ => selected}"}>
+                @if(!labelAfter) {
+                    @if(elements.args.get('_stackedLabel)) {
+                        @if(label.split(" ").length < 2) {<br>@label
+                            } else {
+                                @for( (l, index) <- label.split(" ").zipWithIndex) {
+                                @if(index != 0) {<br>}@l
+                            }
+                        }
+                    } else { @label }
+                }
+                <input
+                    type="radio"
+                    id="@inputId"
+                    name="@elements.field.name"
+                    value="@value"
+                    @elements.args.get('_inputClass).map{inputClass => class="@inputClass"}
+                    @if(elements.args.contains('_dataAttributes) ){ @elements.args.get('_dataAttributes)}
+                    @field.value.filter( _ == value).map{_ => checked="checked"}/>
+                @if(labelAfter) {
+                    @if(elements.args.get('_stackedLabel)) {
+                        @if(label.split(" ").length < 2) {<br>@label
+                            } else {
+                                @for( (l, index) <- label.split(" ").zipWithIndex) {
+                                @if(index != 0) {<br>}@l
+                            }
+                        }
+                    } else { @label }
+                }
+            </label>
+        }
+    }
+</fieldset>

--- a/test/controllers/CalculationControllerSpec.scala
+++ b/test/controllers/CalculationControllerSpec.scala
@@ -20,7 +20,7 @@ import java.util.UUID
 import scala.collection.JavaConversions._
 
 import connectors.CalculatorConnector
-import models.{CustomerTypeModel,DisabledTrusteeModel,AnnualExemptAmountModel}
+import models.{DisabledTrusteeModel, AnnualExemptAmountModel, CustomerTypeModel}
 import org.scalatest.BeforeAndAfterEach
 import org.mockito.Matchers
 import org.mockito.Mockito._
@@ -36,7 +36,7 @@ import org.scalatest.mock.MockitoSugar
 import scala.concurrent.Future
 
 
-class CalculationControllerSpec extends UnitSpec with WithFakeApplication with MockitoSugar with BeforeAndAfterEach{
+class CalculationControllerSpec extends UnitSpec with WithFakeApplication with MockitoSugar with BeforeAndAfterEach {
 
   val s = "Action(parser=BodyParser(anyContent))"
   val sessionId = UUID.randomUUID.toString
@@ -50,7 +50,7 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication with M
   class fakeRequestTo(url: String, controllerAction: Action[AnyContent]) {
     val fakeRequest = FakeRequest("GET", "/calculate-your-capital-gains/" + url).withSession(SessionKeys.sessionId -> s"session-$sessionId")
     val result = controllerAction(fakeRequest)
-    val jsoupDoc = Jsoup.parse(bodyOf(controllerAction(fakeRequest)))
+    val jsoupDoc = Jsoup.parse(bodyOf(result))
   }
 
   def keystoreFetchCondition[T](data: Option[T]): Unit = {
@@ -61,8 +61,7 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication with M
   //################### Customer Type tests #######################
   "In CalculationController calling the .customerType action " when {
     "not supplied with a pre-existing stored model" should {
-
-      object CustomerTypeTestDataItem extends fakeRequestTo("customer-type354", TestCalculationController.customerType)
+      object CustomerTypeTestDataItem extends fakeRequestTo("customer-type", TestCalculationController.customerType)
 
       "return a 200" in {
         keystoreFetchCondition[CustomerTypeModel](None)
@@ -373,11 +372,14 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication with M
 
         "have the value 1000 auto-filled into the input box" in {
           keystoreFetchCondition[AnnualExemptAmountModel](Some(testModel))
-          AnnualExemptAmountTestDataItem.jsoupDoc.getElementById("annualExemptAmount").attr("value") shouldEqual("1000")
+          AnnualExemptAmountTestDataItem.jsoupDoc.getElementById("annualExemptAmount").attr("value") shouldEqual ("1000")
         }
       }
     }
   }
+
+  object AnnualExemptAmountTestDataItem extends fakeRequestTo("allowance", CalculationController.annualExemptAmount)
+
 
   //############## Acquisition Value tests ######################
   "In CalculationController calling the .acquisitionValue action " should {
@@ -448,7 +450,7 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication with M
         ImprovementsTestDataItem.jsoupDoc.body.getElementById("improvementsCheckYes").parent.text shouldEqual Messages("calc.base.yes")
       }
 
-      "display the correct wording for radio option `no`" in{
+      "display the correct wording for radio option `no`" in {
         ImprovementsTestDataItem.jsoupDoc.body.getElementById("improvementsCheckNo").parent.text shouldEqual Messages("calc.base.no")
       }
 
@@ -733,10 +735,10 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication with M
       "have a hidden help text section with summary 'What are allowable losses?' and correct content" in {
         AllowableLossesTestDataItem.jsoupDoc.select("div#allowableLossesHiddenHelp").text should
           include(Messages("calc.allowableLosses.helpText.title"))
-          include(Messages("calc.allowableLosses.helpText.paragraph.one"))
-          include(Messages("calc.allowableLosses.helpText.bullet.one"))
-          include(Messages("calc.allowableLosses.helpText.bullet.two"))
-          include(Messages("calc.allowableLosses.helpText.bullet.three"))
+        include(Messages("calc.allowableLosses.helpText.paragraph.one"))
+        include(Messages("calc.allowableLosses.helpText.bullet.one"))
+        include(Messages("calc.allowableLosses.helpText.bullet.two"))
+        include(Messages("calc.allowableLosses.helpText.bullet.three"))
       }
 
       "has a Continue button" in {
@@ -822,98 +824,98 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication with M
       "have a 'Calculation details' section that" should {
 
         "include the section heading 'Calculation details" in {
-          SummaryTestDataItem.jsoupDoc.select("#calcDetails").text should include (Messages("calc.summary.calculation.details.title"))
+          SummaryTestDataItem.jsoupDoc.select("#calcDetails").text should include(Messages("calc.summary.calculation.details.title"))
         }
 
         "include 'Your total gain'" in {
-          SummaryTestDataItem.jsoupDoc.select("#calcDetails").text should include (Messages("calc.summary.calculation.details.totalGain"))
+          SummaryTestDataItem.jsoupDoc.select("#calcDetails").text should include(Messages("calc.summary.calculation.details.totalGain"))
         }
 
         "include 'Your taxable gain'" in {
-          SummaryTestDataItem.jsoupDoc.select("#calcDetails").text should include (Messages("calc.summary.calculation.details.taxableGain"))
+          SummaryTestDataItem.jsoupDoc.select("#calcDetails").text should include(Messages("calc.summary.calculation.details.taxableGain"))
         }
 
         "include 'Your tax rate'" in {
-          SummaryTestDataItem.jsoupDoc.select("#calcDetails").text should include (Messages("calc.summary.calculation.details.taxRate"))
+          SummaryTestDataItem.jsoupDoc.select("#calcDetails").text should include(Messages("calc.summary.calculation.details.taxRate"))
         }
       }
 
       "have a 'Personal details' section that" should {
 
         "include the section heading 'Personal details" in {
-          SummaryTestDataItem.jsoupDoc.select("#personalDetails").text should include (Messages("calc.summary.personal.details.title"))
+          SummaryTestDataItem.jsoupDoc.select("#personalDetails").text should include(Messages("calc.summary.personal.details.title"))
         }
 
         "include the question 'Who owned the property?'" in {
-          SummaryTestDataItem.jsoupDoc.select("#personalDetails").text should include (Messages("calc.customerType.question"))
+          SummaryTestDataItem.jsoupDoc.select("#personalDetails").text should include(Messages("calc.customerType.question"))
         }
 
         "include the question 'Are you a trustee for someone who's vulnerable'" in {
-          SummaryTestDataItem.jsoupDoc.select("#personalDetails").text should include (Messages("calc.disabledTrustee.question"))
+          SummaryTestDataItem.jsoupDoc.select("#personalDetails").text should include(Messages("calc.disabledTrustee.question"))
         }
 
         "include the question 'How much of your Capital Gains Tax allowance have you got left'" in {
-          SummaryTestDataItem.jsoupDoc.select("#personalDetails").text should include (Messages("calc.annualExemptAmount.question"))
+          SummaryTestDataItem.jsoupDoc.select("#personalDetails").text should include(Messages("calc.annualExemptAmount.question"))
         }
       }
 
       "have a 'Purchase details' section that" should {
 
         "include the section heading 'Purchase details" in {
-          SummaryTestDataItem.jsoupDoc.select("#purchaseDetails").text should include (Messages("calc.summary.purchase.details.title"))
+          SummaryTestDataItem.jsoupDoc.select("#purchaseDetails").text should include(Messages("calc.summary.purchase.details.title"))
         }
 
         "include the question 'How much did you pay for the property?'" in {
-          SummaryTestDataItem.jsoupDoc.select("#purchaseDetails").text should include (Messages("calc.acquisitionValue.question"))
+          SummaryTestDataItem.jsoupDoc.select("#purchaseDetails").text should include(Messages("calc.acquisitionValue.question"))
         }
 
         "include the question 'How much did you pay in costs when you became the property owner?'" in {
-          SummaryTestDataItem.jsoupDoc.select("#purchaseDetails").text should include (Messages("calc.acquisitionCosts.question"))
+          SummaryTestDataItem.jsoupDoc.select("#purchaseDetails").text should include(Messages("calc.acquisitionCosts.question"))
         }
       }
 
       "have a 'Property details' section that" should {
 
         "include the section heading 'Property details" in {
-          SummaryTestDataItem.jsoupDoc.select("#propertyDetails").text should include (Messages("calc.summary.property.details.title"))
+          SummaryTestDataItem.jsoupDoc.select("#propertyDetails").text should include(Messages("calc.summary.property.details.title"))
         }
 
         "include the question 'How much did you pay for the property?'" in {
-          SummaryTestDataItem.jsoupDoc.select("#propertyDetails").text should include (Messages("calc.improvements.question"))
+          SummaryTestDataItem.jsoupDoc.select("#propertyDetails").text should include(Messages("calc.improvements.question"))
         }
       }
 
       "have a 'Sale details' section that" should {
 
         "include the section heading 'Sale details" in {
-          SummaryTestDataItem.jsoupDoc.select("#saleDetails").text should include (Messages("calc.summary.sale.details.title"))
+          SummaryTestDataItem.jsoupDoc.select("#saleDetails").text should include(Messages("calc.summary.sale.details.title"))
         }
 
         "include the question 'When did you sign the contract that made someone else the owner?'" in {
-          SummaryTestDataItem.jsoupDoc.select("#saleDetails").text should include (Messages("calc.disposalDate.question"))
+          SummaryTestDataItem.jsoupDoc.select("#saleDetails").text should include(Messages("calc.disposalDate.question"))
         }
 
         "include the question 'How much did you sell or give away the property for?'" in {
-          SummaryTestDataItem.jsoupDoc.select("#saleDetails").text should include (Messages("calc.disposalValue.question"))
+          SummaryTestDataItem.jsoupDoc.select("#saleDetails").text should include(Messages("calc.disposalValue.question"))
         }
 
         "include the question 'How much did you pay in costs when you stopped being the property owner?'" in {
-          SummaryTestDataItem.jsoupDoc.select("#saleDetails").text should include (Messages("calc.disposalCosts.question"))
+          SummaryTestDataItem.jsoupDoc.select("#saleDetails").text should include(Messages("calc.disposalCosts.question"))
         }
       }
 
       "have a 'Deductions details' section that" should {
 
         "include the section heading 'Deductions" in {
-          SummaryTestDataItem.jsoupDoc.select("#deductions").text should include (Messages("calc.summary.deductions.title"))
+          SummaryTestDataItem.jsoupDoc.select("#deductions").text should include(Messages("calc.summary.deductions.title"))
         }
 
         "include the question 'Are you claiming Entrepreneurs' Relief?'" in {
-          SummaryTestDataItem.jsoupDoc.select("#deductions").text should include (Messages("calc.entrepreneursRelief.question"))
+          SummaryTestDataItem.jsoupDoc.select("#deductions").text should include(Messages("calc.entrepreneursRelief.question"))
         }
 
         "include the question 'Whats the total value of your allowable losses?'" in {
-          SummaryTestDataItem.jsoupDoc.select("#deductions").text should include (Messages("calc.allowableLosses.question.two"))
+          SummaryTestDataItem.jsoupDoc.select("#deductions").text should include(Messages("calc.allowableLosses.question.two"))
         }
       }
 
@@ -925,8 +927,8 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication with M
 
         "include the text 'You need to tell HMRC about the property'" in {
           SummaryTestDataItem.jsoupDoc.select("#whatToDoNext").text should
-            include (Messages("calc.summary.next.actions.text"))
-            include (Messages("calc.summary.next.actions.link"))
+            include(Messages("calc.summary.next.actions.text"))
+          include(Messages("calc.summary.next.actions.link"))
         }
       }
 

--- a/test/controllers/CalculationControllerSpec.scala
+++ b/test/controllers/CalculationControllerSpec.scala
@@ -20,7 +20,7 @@ import java.util.UUID
 import scala.collection.JavaConversions._
 
 import connectors.CalculatorConnector
-import models.CustomerTypeModel
+import models.{CustomerTypeModel,DisabledTrusteeModel}
 import org.scalatest.BeforeAndAfterEach
 import org.mockito.Matchers
 import org.mockito.Mockito._
@@ -50,7 +50,7 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication with M
   class fakeRequestTo(url: String, controllerAction: Action[AnyContent]) {
     val fakeRequest = FakeRequest("GET", "/calculate-your-capital-gains/" + url).withSession(SessionKeys.sessionId -> s"session-$sessionId")
     val result = controllerAction(fakeRequest)
-    val jsoupDoc = Jsoup.parse(bodyOf(result))
+    val jsoupDoc = Jsoup.parse(bodyOf(controllerAction(fakeRequest)))
   }
 
   def keystoreFetchCondition[T](data: Option[T]): Unit = {
@@ -61,7 +61,8 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication with M
   //################### Customer Type tests #######################
   "In CalculationController calling the .customerType action " when {
     "not supplied with a pre-existing stored model" should {
-      object CustomerTypeTestDataItem extends fakeRequestTo("customer-type", TestCalculationController.customerType)
+
+      object CustomerTypeTestDataItem extends fakeRequestTo("customer-type354", TestCalculationController.customerType)
 
       "return a 200" in {
         keystoreFetchCondition[CustomerTypeModel](None)
@@ -147,593 +148,621 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication with M
   }
 
   //################### Disabled Trustee tests #######################
-  "In CalculationController calling the .disabledTrustee action " should {
+  "In CalculationController calling the .disabledTrustee action " when {
 
-    object DisabledTrusteeTestDataItem extends fakeRequestTo("disabled-trustee", CalculationController.disabledTrustee)
+    "not supplied with a pre-existing stored model" should {
+
+      object DisabledTrusteeTestDataItem extends fakeRequestTo("disabled-trustee", TestCalculationController.disabledTrustee)
+
+      "return a 200" in {
+        keystoreFetchCondition[DisabledTrusteeModel](None)
+        status(DisabledTrusteeTestDataItem.result) shouldBe 200
+      }
+
+      "return some HTML that" should {
+        "contain some text and use the character set utf-8" in {
+          keystoreFetchCondition[DisabledTrusteeModel](None)
+          contentType(DisabledTrusteeTestDataItem.result) shouldBe Some("text/html")
+          charset(DisabledTrusteeTestDataItem.result) shouldBe Some("utf-8")
+        }
+
+        "have the title Are you a trustee for someone who’s vulnerable?" in {
+          keystoreFetchCondition[DisabledTrusteeModel](None)
+          DisabledTrusteeTestDataItem.jsoupDoc.title shouldEqual Messages("calc.disabledTrustee.question")
+        }
+
+        "have the heading Calculate your tax (non-residents) " in {
+          keystoreFetchCondition[DisabledTrusteeModel](None)
+          DisabledTrusteeTestDataItem.jsoupDoc.body.getElementsByTag("h1").text shouldEqual Messages("calc.base.pageHeading")
+        }
+
+        "have a 'Back' link " in {
+          keystoreFetchCondition[DisabledTrusteeModel](None)
+          DisabledTrusteeTestDataItem.jsoupDoc.body.getElementById("link-back").text shouldEqual Messages("calc.base.back")
+        }
+
+        "have the question 'When did you sign the contract that made someone else the owner?' as the legend of the input" in {
+          keystoreFetchCondition[DisabledTrusteeModel](None)
+          DisabledTrusteeTestDataItem.jsoupDoc.body.getElementsByTag("legend").text shouldEqual Messages("calc.disabledTrustee.question")
+        }
+
+        "display a radio button with the option 'Yes'" in {
+          keystoreFetchCondition[DisabledTrusteeModel](None)
+          DisabledTrusteeTestDataItem.jsoupDoc.body.getElementById("isVulnerable-yes").parent.text shouldEqual Messages("calc.base.yes")
+        }
+
+        "display a radio button with the option 'No'" in {
+          keystoreFetchCondition[DisabledTrusteeModel](None)
+          DisabledTrusteeTestDataItem.jsoupDoc.body.getElementById("isVulnerable-no").parent.text shouldEqual Messages("calc.base.no")
+        }
+
+        "display a 'Continue' button " in {
+          keystoreFetchCondition[DisabledTrusteeModel](None)
+          DisabledTrusteeTestDataItem.jsoupDoc.body.getElementById("continue-button").text shouldEqual Messages("calc.base.continue")
+        }
+      }
+    }
+    "supplied with a pre-existing stored model" should {
+
+      "return some HTML that" should {
+
+        "have the radio option `Yes` selected if `Yes` is supplied in the model" in {
+          object DisabledTrusteeTestDataItem extends fakeRequestTo("disabled-trustee", TestCalculationController.disabledTrustee)
+          keystoreFetchCondition[DisabledTrusteeModel](Some(DisabledTrusteeModel("Yes")))
+          DisabledTrusteeTestDataItem.jsoupDoc.body.getElementById("isVulnerable-yes").parent.classNames().contains("selected") shouldBe true
+        }
+
+        "have the radio option `No` selected if `No` is supplied in the model" in {
+          object DisabledTrusteeTestDataItem extends fakeRequestTo("disabled-trustee", TestCalculationController.disabledTrustee)
+          keystoreFetchCondition[DisabledTrusteeModel](Some(DisabledTrusteeModel("No")))
+          DisabledTrusteeTestDataItem.jsoupDoc.body.getElementById("isVulnerable-no").parent.classNames().contains("selected") shouldBe true
+        }
+      }
+    }
+  }
+
+  //################### Current Income tests #######################
+  "In CalculationController calling the .currentIncome action " should {
+
+    "be Action(parser=BodyParser(anyContent)) for currentIncome" in {
+      val result = CalculationController.currentIncome.toString()
+      result shouldBe s
+    }
+  }
+
+  //############## Personal Allowance tests ######################
+  "In CalculationController calling the .personalAllowance action " should {
+
+    object PersonalAllowanceTestDataItem extends fakeRequestTo("personal-allowance", CalculationController.personalAllowance)
 
     "return a 200" in {
-      status(DisabledTrusteeTestDataItem.result) shouldBe 200
+      status(PersonalAllowanceTestDataItem.result) shouldBe 200
     }
 
     "return some HTML that" should {
 
       "contain some text and use the character set utf-8" in {
-        contentType(DisabledTrusteeTestDataItem.result) shouldBe Some("text/html")
-        charset(DisabledTrusteeTestDataItem.result) shouldBe Some("utf-8")
+        contentType(PersonalAllowanceTestDataItem.result) shouldBe Some("text/html")
+        charset(PersonalAllowanceTestDataItem.result) shouldBe Some("utf-8")
+      }
+    }
+  }
+
+  //############## Other Properties tests ######################
+  "In CalculationController calling the .otherProperties action " should {
+
+    object OtherPropertiesTestDataItem extends fakeRequestTo("other-properties", CalculationController.otherProperties)
+
+    "return a 200" in {
+      status(OtherPropertiesTestDataItem.result) shouldBe 200
+    }
+
+    "return some HTML that" should {
+
+      "contain some text and use the character set utf-8" in {
+        contentType(OtherPropertiesTestDataItem.result) shouldBe Some("text/html")
+        charset(OtherPropertiesTestDataItem.result) shouldBe Some("utf-8")
       }
 
-      "have the title Are you a trustee for someone who’s vulnerable?" in {
-        DisabledTrusteeTestDataItem.jsoupDoc.title shouldEqual Messages("calc.disabledTrustee.question")
+      "have the title 'Did you sell or give away any other properties in that tax year?'" in {
+        OtherPropertiesTestDataItem.jsoupDoc.title shouldEqual Messages("calc.otherProperties.question")
       }
 
       "have the heading Calculate your tax (non-residents) " in {
-        DisabledTrusteeTestDataItem.jsoupDoc.body.getElementsByTag("h1").text shouldEqual Messages("calc.base.pageHeading")
+        OtherPropertiesTestDataItem.jsoupDoc.body.getElementsByTag("h1").text shouldEqual Messages("calc.base.pageHeading")
       }
 
       "have a 'Back' link " in {
-        DisabledTrusteeTestDataItem.jsoupDoc.body.getElementById("link-back").text shouldEqual Messages("calc.base.back")
+        OtherPropertiesTestDataItem.jsoupDoc.body.getElementById("link-back").text shouldEqual Messages("calc.base.back")
       }
 
-      "have the question 'When did you sign the contract that made someone else the owner?' as the legend of the input" in {
-        DisabledTrusteeTestDataItem.jsoupDoc.body.getElementsByTag("legend").text shouldEqual Messages("calc.disabledTrustee.question")
+      "have the question 'Did you sell or give away any other properties in that tax year?' as the legend of the input" in {
+        OtherPropertiesTestDataItem.jsoupDoc.body.getElementsByTag("legend").text shouldEqual Messages("calc.otherProperties.question")
       }
 
-      "display a radio button with the option 'Yes'" in {
-        DisabledTrusteeTestDataItem.jsoupDoc.body.getElementById("isVulnerableYes").parent.text shouldEqual Messages("calc.base.yes")
+      "display a radio button with the option `Yes`" in {
+        OtherPropertiesTestDataItem.jsoupDoc.body.getElementById("otherPropertiesYes").parent.text shouldEqual Messages("calc.base.yes")
       }
 
-      "display a radio button with the option 'No'" in {
-        DisabledTrusteeTestDataItem.jsoupDoc.body.getElementById("isVulnerableNo").parent.text shouldEqual Messages("calc.base.no")
+      "display a radio button with the option `No`" in {
+        OtherPropertiesTestDataItem.jsoupDoc.body.getElementById("otherPropertiesNo").parent.text shouldEqual Messages("calc.base.no")
       }
 
       "display a 'Continue' button " in {
-        DisabledTrusteeTestDataItem.jsoupDoc.body.getElementById("continue-button").text shouldEqual Messages("calc.base.continue")
+        OtherPropertiesTestDataItem.jsoupDoc.body.getElementById("continue-button").text shouldEqual Messages("calc.base.continue")
       }
     }
+  }
 
-    //################### Current Income tests #######################
-    "In CalculationController calling the .currentIncome action " should {
+  //############## Annual Exempt Amount tests ######################
+  "In CalculationController calling the .annualExemptAmount action " should {
 
-      "be Action(parser=BodyParser(anyContent)) for currentIncome" in {
-        val result = CalculationController.currentIncome.toString()
-        result shouldBe s
-      }
+    object AnnualExemptAmountTestDataItem extends fakeRequestTo("allowance", CalculationController.annualExemptAmount)
+
+    "return a 200" in {
+      status(AnnualExemptAmountTestDataItem.result) shouldBe 200
     }
 
-    //############## Personal Allowance tests ######################
-    "In CalculationController calling the .personalAllowance action " should {
+    "return some HTML that" should {
 
-      object PersonalAllowanceTestDataItem extends fakeRequestTo("personal-allowance", CalculationController.personalAllowance)
-
-      "return a 200" in {
-        status(PersonalAllowanceTestDataItem.result) shouldBe 200
+      "contain some text and use the character set utf-8" in {
+        contentType(AnnualExemptAmountTestDataItem.result) shouldBe Some("text/html")
+        charset(AnnualExemptAmountTestDataItem.result) shouldBe Some("utf-8")
       }
 
-      "return some HTML that" should {
-
-        "contain some text and use the character set utf-8" in {
-          contentType(PersonalAllowanceTestDataItem.result) shouldBe Some("text/html")
-          charset(PersonalAllowanceTestDataItem.result) shouldBe Some("utf-8")
-        }
-      }
-    }
-
-    //############## Other Properties tests ######################
-    "In CalculationController calling the .otherProperties action " should {
-
-      object OtherPropertiesTestDataItem extends fakeRequestTo("other-properties", CalculationController.otherProperties)
-
-      "return a 200" in {
-        status(OtherPropertiesTestDataItem.result) shouldBe 200
+      "have the title 'How much of your Capital Gains Tax allowance have you got left?'" in {
+        AnnualExemptAmountTestDataItem.jsoupDoc.title shouldEqual Messages("calc.annualExemptAmount.question")
       }
 
-      "return some HTML that" should {
+      "have the heading Calculate your tax (non-residents) " in {
+        AnnualExemptAmountTestDataItem.jsoupDoc.body.getElementsByTag("h1").text shouldEqual Messages("calc.base.pageHeading")
+      }
 
-        "contain some text and use the character set utf-8" in {
-          contentType(OtherPropertiesTestDataItem.result) shouldBe Some("text/html")
-          charset(OtherPropertiesTestDataItem.result) shouldBe Some("utf-8")
-        }
+      "have a 'Back' link " in {
+        AnnualExemptAmountTestDataItem.jsoupDoc.body.getElementById("link-back").text shouldEqual Messages("calc.base.back")
+      }
 
-        "have the title 'Did you sell or give away any other properties in that tax year?'" in {
-          OtherPropertiesTestDataItem.jsoupDoc.title shouldEqual Messages("calc.otherProperties.question")
-        }
+      "have the question 'How much of your Capital Gains Tax allowance have you got left?' as the legend of the input" in {
+        AnnualExemptAmountTestDataItem.jsoupDoc.body.getElementsByTag("label").text shouldEqual Messages("calc.annualExemptAmount.question")
+      }
 
-        "have the heading Calculate your tax (non-residents) " in {
-          OtherPropertiesTestDataItem.jsoupDoc.body.getElementsByTag("h1").text shouldEqual Messages("calc.base.pageHeading")
-        }
+      "display an input box for the Annual Exempt Amount" in {
+        AnnualExemptAmountTestDataItem.jsoupDoc.body.getElementById("annualExemptAmount").tagName() shouldEqual "input"
+      }
 
-        "have a 'Back' link " in {
-          OtherPropertiesTestDataItem.jsoupDoc.body.getElementById("link-back").text shouldEqual Messages("calc.base.back")
-        }
+      "display a 'Continue' button " in {
+        AnnualExemptAmountTestDataItem.jsoupDoc.body.getElementById("continue-button").text shouldEqual Messages("calc.base.continue")
+      }
 
-        "have the question 'Did you sell or give away any other properties in that tax year?' as the legend of the input" in {
-          OtherPropertiesTestDataItem.jsoupDoc.body.getElementsByTag("legend").text shouldEqual Messages("calc.otherProperties.question")
-        }
-
-        "display a radio button with the option `Yes`" in {
-          OtherPropertiesTestDataItem.jsoupDoc.body.getElementById("otherPropertiesYes").parent.text shouldEqual Messages("calc.base.yes")
-        }
-
-        "display a radio button with the option `No`" in {
-          OtherPropertiesTestDataItem.jsoupDoc.body.getElementById("otherPropertiesNo").parent.text shouldEqual Messages("calc.base.no")
-        }
-
-        "display a 'Continue' button " in {
-          OtherPropertiesTestDataItem.jsoupDoc.body.getElementById("continue-button").text shouldEqual Messages("calc.base.continue")
-        }
+      "should contain a Read more sidebar with a link to CGT allowances" in {
+        AnnualExemptAmountTestDataItem.jsoupDoc.select("aside h2").text shouldBe Messages("calc.common.readMore")
+        AnnualExemptAmountTestDataItem.jsoupDoc.select("aside a").text shouldBe Messages("calc.annualExemptAmount.link.one")
       }
     }
+  }
 
-    //############## Annual Exempt Amount tests ######################
-    "In CalculationController calling the .annualExemptAmount action " should {
+  //############## Acquisition Value tests ######################
+  "In CalculationController calling the .acquisitionValue action " should {
 
-      object AnnualExemptAmountTestDataItem extends fakeRequestTo("allowance", CalculationController.annualExemptAmount)
+    object AcquisitonValueTestDataItem extends fakeRequestTo("acquisition-value", CalculationController.acquisitionValue)
 
-      "return a 200" in {
-        status(AnnualExemptAmountTestDataItem.result) shouldBe 200
-      }
-
-      "return some HTML that" should {
-
-        "contain some text and use the character set utf-8" in {
-          contentType(AnnualExemptAmountTestDataItem.result) shouldBe Some("text/html")
-          charset(AnnualExemptAmountTestDataItem.result) shouldBe Some("utf-8")
-        }
-
-        "have the title 'How much of your Capital Gains Tax allowance have you got left?'" in {
-          AnnualExemptAmountTestDataItem.jsoupDoc.title shouldEqual Messages("calc.annualExemptAmount.question")
-        }
-
-        "have the heading Calculate your tax (non-residents) " in {
-          AnnualExemptAmountTestDataItem.jsoupDoc.body.getElementsByTag("h1").text shouldEqual Messages("calc.base.pageHeading")
-        }
-
-        "have a 'Back' link " in {
-          AnnualExemptAmountTestDataItem.jsoupDoc.body.getElementById("link-back").text shouldEqual Messages("calc.base.back")
-        }
-
-        "have the question 'How much of your Capital Gains Tax allowance have you got left?' as the legend of the input" in {
-          AnnualExemptAmountTestDataItem.jsoupDoc.body.getElementsByTag("label").text shouldEqual Messages("calc.annualExemptAmount.question")
-        }
-
-        "display an input box for the Annual Exempt Amount" in {
-          AnnualExemptAmountTestDataItem.jsoupDoc.body.getElementById("annualExemptAmount").tagName() shouldEqual "input"
-        }
-
-        "display a 'Continue' button " in {
-          AnnualExemptAmountTestDataItem.jsoupDoc.body.getElementById("continue-button").text shouldEqual Messages("calc.base.continue")
-        }
-
-        "should contain a Read more sidebar with a link to CGT allowances" in {
-          AnnualExemptAmountTestDataItem.jsoupDoc.select("aside h2").text shouldBe Messages("calc.common.readMore")
-          AnnualExemptAmountTestDataItem.jsoupDoc.select("aside a").text shouldBe Messages("calc.annualExemptAmount.link.one")
-        }
-      }
+    "return a 200" in {
+      status(AcquisitonValueTestDataItem.result) shouldBe 200
     }
 
-    //############## Acquisition Value tests ######################
-    "In CalculationController calling the .acquisitionValue action " should {
+    "return some HTML that" should {
 
-      object AcquisitonValueTestDataItem extends fakeRequestTo("acquisition-value", CalculationController.acquisitionValue)
-
-      "return a 200" in {
-        status(AcquisitonValueTestDataItem.result) shouldBe 200
+      "contain some text and use the character set utf-8" in {
+        contentType(AcquisitonValueTestDataItem.result) shouldBe Some("text/html")
+        charset(AcquisitonValueTestDataItem.result) shouldBe Some("utf-8")
       }
 
-      "return some HTML that" should {
+      "have the title 'How much did you pay for the property?'" in {
+        AcquisitonValueTestDataItem.jsoupDoc.title shouldEqual Messages("calc.acquisitionValue.question")
+      }
 
-        "contain some text and use the character set utf-8" in {
-          contentType(AcquisitonValueTestDataItem.result) shouldBe Some("text/html")
-          charset(AcquisitonValueTestDataItem.result) shouldBe Some("utf-8")
-        }
+      "have the heading Calculate your tax (non-residents) " in {
+        AcquisitonValueTestDataItem.jsoupDoc.body.getElementsByTag("h1").text shouldEqual Messages("calc.base.pageHeading")
+      }
 
-        "have the title 'How much did you pay for the property?'" in {
-          AcquisitonValueTestDataItem.jsoupDoc.title shouldEqual Messages("calc.acquisitionValue.question")
-        }
+      "have a 'Back' link " in {
+        AcquisitonValueTestDataItem.jsoupDoc.body.getElementById("link-back").text shouldEqual Messages("calc.base.back")
+      }
 
-        "have the heading Calculate your tax (non-residents) " in {
-          AcquisitonValueTestDataItem.jsoupDoc.body.getElementsByTag("h1").text shouldEqual Messages("calc.base.pageHeading")
-        }
+      "have the question 'How much did you pay for the property?'" in {
+        AcquisitonValueTestDataItem.jsoupDoc.body.getElementsByTag("label").text shouldEqual Messages("calc.acquisitionValue.question")
+      }
 
-        "have a 'Back' link " in {
-          AcquisitonValueTestDataItem.jsoupDoc.body.getElementById("link-back").text shouldEqual Messages("calc.base.back")
-        }
-
-        "have the question 'How much did you pay for the property?'" in {
-          AcquisitonValueTestDataItem.jsoupDoc.body.getElementsByTag("label").text shouldEqual Messages("calc.acquisitionValue.question")
-        }
-
-        "display an input box for the Acquisition Value" in {
-          AcquisitonValueTestDataItem.jsoupDoc.body.getElementById("acquisitionValue").tagName shouldEqual "input"
-        }
-        "display a 'Continue' button " in {
-          AcquisitonValueTestDataItem.jsoupDoc.body.getElementById("continue-button").text shouldEqual Messages("calc.base.continue")
-        }
+      "display an input box for the Acquisition Value" in {
+        AcquisitonValueTestDataItem.jsoupDoc.body.getElementById("acquisitionValue").tagName shouldEqual "input"
+      }
+      "display a 'Continue' button " in {
+        AcquisitonValueTestDataItem.jsoupDoc.body.getElementById("continue-button").text shouldEqual Messages("calc.base.continue")
       }
     }
+  }
 
-    //################### Improvements tests #######################
-    "In CalculationController calling the .improvements action " should {
+  //################### Improvements tests #######################
+  "In CalculationController calling the .improvements action " should {
 
-      object ImprovementsTestDataItem extends fakeRequestTo("improvements", CalculationController.improvements)
+    object ImprovementsTestDataItem extends fakeRequestTo("improvements", CalculationController.improvements)
 
-      "return a 200" in {
-        status(ImprovementsTestDataItem.result) shouldBe 200
-      }
-
-      "return some HTML that" should {
-
-        "contain some text and use the character set utf-8" in {
-          contentType(ImprovementsTestDataItem.result) shouldBe Some("text/html")
-          charset(ImprovementsTestDataItem.result) shouldBe Some("utf-8")
-        }
-
-        "have the title 'Who owned the property?'" in {
-          ImprovementsTestDataItem.jsoupDoc.title shouldEqual Messages("calc.improvements.question")
-        }
-
-        "have the heading Calculate your tax (non-residents)" in {
-          ImprovementsTestDataItem.jsoupDoc.body.getElementsByTag("H1").text shouldEqual Messages("calc.base.pageHeading")
-        }
-
-        "display the correct wording for radio option `yes`" in {
-          ImprovementsTestDataItem.jsoupDoc.body.getElementById("improvementsCheckYes").parent.text shouldEqual Messages("calc.base.yes")
-        }
-
-        "display the correct wording for radio option `no`" in{
-          ImprovementsTestDataItem.jsoupDoc.body.getElementById("improvementsCheckNo").parent.text shouldEqual Messages("calc.base.no")
-        }
-
-        "contain a hidden component with an input box" in {
-          ImprovementsTestDataItem.jsoupDoc.body.getElementById("improvements").parent.parent.id shouldBe "hidden"
-        }
-      }
+    "return a 200" in {
+      status(ImprovementsTestDataItem.result) shouldBe 200
     }
 
+    "return some HTML that" should {
 
-    //################### Disposal Date tests #######################
-    "In CalculationController calling the .disposalDate action " should {
-
-      object DisposalDateTestDataItem extends fakeRequestTo("disposal-date", CalculationController.disposalDate)
-
-      "return a 200" in {
-        status(DisposalDateTestDataItem.result) shouldBe 200
+      "contain some text and use the character set utf-8" in {
+        contentType(ImprovementsTestDataItem.result) shouldBe Some("text/html")
+        charset(ImprovementsTestDataItem.result) shouldBe Some("utf-8")
       }
 
-      "return some HTML that" should {
+      "have the title 'Who owned the property?'" in {
+        ImprovementsTestDataItem.jsoupDoc.title shouldEqual Messages("calc.improvements.question")
+      }
 
-        "contain some text and use the character set utf-8" in {
-          contentType(DisposalDateTestDataItem.result) shouldBe Some("text/html")
-          charset(DisposalDateTestDataItem.result) shouldBe Some("utf-8")
-        }
+      "have the heading Calculate your tax (non-residents)" in {
+        ImprovementsTestDataItem.jsoupDoc.body.getElementsByTag("H1").text shouldEqual Messages("calc.base.pageHeading")
+      }
 
-        "have the title 'When did you sign the contract that made someone else the owner?'" in {
-          DisposalDateTestDataItem.jsoupDoc.title shouldEqual Messages("calc.disposalDate.question")
-        }
+      "display the correct wording for radio option `yes`" in {
+        ImprovementsTestDataItem.jsoupDoc.body.getElementById("improvementsCheckYes").parent.text shouldEqual Messages("calc.base.yes")
+      }
 
-        "have the heading Calculate your tax (non-residents) " in {
-          DisposalDateTestDataItem.jsoupDoc.body.getElementsByTag("h1").text shouldEqual Messages("calc.base.pageHeading")
-        }
+      "display the correct wording for radio option `no`" in{
+        ImprovementsTestDataItem.jsoupDoc.body.getElementById("improvementsCheckNo").parent.text shouldEqual Messages("calc.base.no")
+      }
 
-        "have a 'Back' link " in {
-          DisposalDateTestDataItem.jsoupDoc.body.getElementById("link-back").text shouldEqual Messages("calc.base.back")
-        }
-
-        "have the question 'Who owned the property?' as the legend of the input" in {
-          DisposalDateTestDataItem.jsoupDoc.body.getElementsByTag("legend").text shouldEqual Messages("calc.disposalDate.question")
-        }
-
-        "display a 'Continue' button " in {
-          DisposalDateTestDataItem.jsoupDoc.body.getElementById("continue-button").text shouldEqual Messages("calc.base.continue")
-        }
+      "contain a hidden component with an input box" in {
+        ImprovementsTestDataItem.jsoupDoc.body.getElementById("improvements").parent.parent.id shouldBe "hidden"
       }
     }
+  }
 
-    //################### Disposal Value tests #######################
-    "In CalculationController calling the .disposalValue action " should {
 
-      object DisposalValueTestDataItem extends fakeRequestTo("disposal-value", CalculationController.disposalValue)
+  //################### Disposal Date tests #######################
+  "In CalculationController calling the .disposalDate action " should {
 
-      "return a 200" in {
-        status(DisposalValueTestDataItem.result) shouldBe 200
+    object DisposalDateTestDataItem extends fakeRequestTo("disposal-date", CalculationController.disposalDate)
+
+    "return a 200" in {
+      status(DisposalDateTestDataItem.result) shouldBe 200
+    }
+
+    "return some HTML that" should {
+
+      "contain some text and use the character set utf-8" in {
+        contentType(DisposalDateTestDataItem.result) shouldBe Some("text/html")
+        charset(DisposalDateTestDataItem.result) shouldBe Some("utf-8")
       }
 
-      "return some HTML that" should {
+      "have the title 'When did you sign the contract that made someone else the owner?'" in {
+        DisposalDateTestDataItem.jsoupDoc.title shouldEqual Messages("calc.disposalDate.question")
+      }
 
-        "contain some text and use the character set utf-8" in {
-          contentType(DisposalValueTestDataItem.result) shouldBe Some("text/html")
-          charset(DisposalValueTestDataItem.result) shouldBe Some("utf-8")
+      "have the heading Calculate your tax (non-residents) " in {
+        DisposalDateTestDataItem.jsoupDoc.body.getElementsByTag("h1").text shouldEqual Messages("calc.base.pageHeading")
+      }
+
+      "have a 'Back' link " in {
+        DisposalDateTestDataItem.jsoupDoc.body.getElementById("link-back").text shouldEqual Messages("calc.base.back")
+      }
+
+      "have the question 'Who owned the property?' as the legend of the input" in {
+        DisposalDateTestDataItem.jsoupDoc.body.getElementsByTag("legend").text shouldEqual Messages("calc.disposalDate.question")
+      }
+
+      "display a 'Continue' button " in {
+        DisposalDateTestDataItem.jsoupDoc.body.getElementById("continue-button").text shouldEqual Messages("calc.base.continue")
+      }
+    }
+  }
+
+  //################### Disposal Value tests #######################
+  "In CalculationController calling the .disposalValue action " should {
+
+    object DisposalValueTestDataItem extends fakeRequestTo("disposal-value", CalculationController.disposalValue)
+
+    "return a 200" in {
+      status(DisposalValueTestDataItem.result) shouldBe 200
+    }
+
+    "return some HTML that" should {
+
+      "contain some text and use the character set utf-8" in {
+        contentType(DisposalValueTestDataItem.result) shouldBe Some("text/html")
+        charset(DisposalValueTestDataItem.result) shouldBe Some("utf-8")
+      }
+
+      "have the title 'How much did you sell or give away the property for?'" in {
+        DisposalValueTestDataItem.jsoupDoc.title shouldEqual Messages("calc.disposalValue.question")
+      }
+
+      "have the heading Calculate your tax (non-residents) " in {
+        DisposalValueTestDataItem.jsoupDoc.body.getElementsByTag("h1").text shouldEqual Messages("calc.base.pageHeading")
+      }
+
+      "have a 'Back' link " in {
+        DisposalValueTestDataItem.jsoupDoc.body.getElementById("link-back").text shouldEqual Messages("calc.base.back")
+      }
+
+      "have the question 'How much did you sell or give away the property for?' as the legend of the input" in {
+        DisposalValueTestDataItem.jsoupDoc.body.getElementsByTag("label").text shouldEqual Messages("calc.disposalValue.question")
+      }
+
+      "display an input box for the Annual Exempt Amount" in {
+        DisposalValueTestDataItem.jsoupDoc.body.getElementById("disposalValue").tagName() shouldEqual "input"
+      }
+
+      "display a 'Continue' button " in {
+        DisposalValueTestDataItem.jsoupDoc.body.getElementById("continue-button").text shouldEqual Messages("calc.base.continue")
+      }
+    }
+  }
+
+  //################### Acquisition Costs tests #######################
+  "In CalculationController calling the .acquisitionCosts action " should {
+
+    object AcquisitionCostsTestDataItem extends fakeRequestTo("acquisition-costs", CalculationController.acquisitionCosts)
+
+    "return a 200" in {
+      status(AcquisitionCostsTestDataItem.result) shouldBe 200
+    }
+
+    "return some HTML that" should {
+
+      "contain some text and use the character set utf-8" in {
+        contentType(AcquisitionCostsTestDataItem.result) shouldBe Some("text/html")
+        charset(AcquisitionCostsTestDataItem.result) shouldBe Some("utf-8")
+      }
+
+      "have the title 'How much did you pay in costs when you became the property owner'" in {
+        AcquisitionCostsTestDataItem.jsoupDoc.getElementsByTag("title").text shouldEqual Messages("calc.acquisitionCosts.question")
+      }
+
+      "have a back link" in {
+        AcquisitionCostsTestDataItem.jsoupDoc.getElementById("link-back").text shouldEqual Messages("calc.base.back")
+      }
+
+      "have the page heading 'Calculate your tax (non-residents)'" in {
+        AcquisitionCostsTestDataItem.jsoupDoc.getElementsByTag("h1").text shouldEqual Messages("calc.base.pageHeading")
+      }
+
+      "have a monetary field that" should {
+
+        "have the title 'How much did you pay in costs when you became the property owner?'" in {
+          AcquisitionCostsTestDataItem.jsoupDoc.select("label[for=acquisitionCosts]").text shouldEqual Messages("calc.acquisitionCosts.question")
         }
 
-        "have the title 'How much did you sell or give away the property for?'" in {
-          DisposalValueTestDataItem.jsoupDoc.title shouldEqual Messages("calc.disposalValue.question")
+        "have the help text 'Costs include agent fees, legal fees and surveys'" in {
+          AcquisitionCostsTestDataItem.jsoupDoc.select("span.form-hint").text shouldEqual Messages("calc.acquisitionCosts.helpText")
         }
 
-        "have the heading Calculate your tax (non-residents) " in {
-          DisposalValueTestDataItem.jsoupDoc.body.getElementsByTag("h1").text shouldEqual Messages("calc.base.pageHeading")
+        "have an input box for the acquisition costs" in {
+          AcquisitionCostsTestDataItem.jsoupDoc.getElementById("acquisitionCosts").tagName shouldBe "input"
+        }
+      }
+
+      "have a continue button that" should {
+
+        "be a button element" in {
+          AcquisitionCostsTestDataItem.jsoupDoc.getElementById("continue-button").tagName shouldBe "button"
         }
 
-        "have a 'Back' link " in {
-          DisposalValueTestDataItem.jsoupDoc.body.getElementById("link-back").text shouldEqual Messages("calc.base.back")
-        }
-
-        "have the question 'How much did you sell or give away the property for?' as the legend of the input" in {
-          DisposalValueTestDataItem.jsoupDoc.body.getElementsByTag("label").text shouldEqual Messages("calc.disposalValue.question")
-        }
-
-        "display an input box for the Annual Exempt Amount" in {
-          DisposalValueTestDataItem.jsoupDoc.body.getElementById("disposalValue").tagName() shouldEqual "input"
-        }
-
-        "display a 'Continue' button " in {
-          DisposalValueTestDataItem.jsoupDoc.body.getElementById("continue-button").text shouldEqual Messages("calc.base.continue")
+        "have the text 'Continue'" in {
+          AcquisitionCostsTestDataItem.jsoupDoc.getElementById("continue-button").text shouldEqual Messages("calc.base.continue")
         }
       }
     }
+  }
 
-    //################### Acquisition Costs tests #######################
-    "In CalculationController calling the .acquisitionCosts action " should {
+  //################### Disposal Costs tests #######################
+  "In CalculationController calling the .disposalCosts action " should {
 
-      object AcquisitionCostsTestDataItem extends fakeRequestTo("acquisition-costs", CalculationController.acquisitionCosts)
+    object DisposalCostsTestDataItem extends fakeRequestTo("disposal-costs", CalculationController.disposalCosts)
 
-      "return a 200" in {
-        status(AcquisitionCostsTestDataItem.result) shouldBe 200
+    "return a 200" in {
+      status(DisposalCostsTestDataItem.result) shouldBe 200
+    }
+
+    "return some HTML that" should {
+
+      "contain some text and use the character set utf-8" in {
+        contentType(DisposalCostsTestDataItem.result) shouldBe Some("text/html")
+        charset(DisposalCostsTestDataItem.result) shouldBe Some("utf-8")
       }
 
-      "return some HTML that" should {
+      "have the title 'How much did you pay in costs when you stopped being the property owner?'" in {
+        DisposalCostsTestDataItem.jsoupDoc.getElementsByTag("title").text shouldBe Messages("calc.disposalCosts.question")
+      }
 
-        "contain some text and use the character set utf-8" in {
-          contentType(AcquisitionCostsTestDataItem.result) shouldBe Some("text/html")
-          charset(AcquisitionCostsTestDataItem.result) shouldBe Some("utf-8")
+      "have a back link" in {
+        DisposalCostsTestDataItem.jsoupDoc.getElementById("link-back").text shouldEqual Messages("calc.base.back")
+      }
+
+      "have the heading 'Calculate your tax (non-residents)'" in {
+        DisposalCostsTestDataItem.jsoupDoc.getElementsByTag("h1").text shouldEqual Messages("calc.base.pageHeading")
+      }
+
+      "have a monetary field that" should {
+
+        "have the title 'How much did you pay in costs when you became the property owner?'" in {
+          DisposalCostsTestDataItem.jsoupDoc.select("label[for=disposalCosts]").text shouldEqual Messages("calc.disposalCosts.question")
         }
 
-        "have the title 'How much did you pay in costs when you became the property owner'" in {
-          AcquisitionCostsTestDataItem.jsoupDoc.getElementsByTag("title").text shouldEqual Messages("calc.acquisitionCosts.question")
+        "have an input box for the disposal costs" in {
+          DisposalCostsTestDataItem.jsoupDoc.getElementById("disposalCosts").tagName shouldBe "input"
+        }
+      }
+
+      "have a continue button that" should {
+
+        "be a button element" in {
+          DisposalCostsTestDataItem.jsoupDoc.getElementById("continue-button").tagName shouldBe "button"
         }
 
-        "have a back link" in {
-          AcquisitionCostsTestDataItem.jsoupDoc.getElementById("link-back").text shouldEqual Messages("calc.base.back")
-        }
-
-        "have the page heading 'Calculate your tax (non-residents)'" in {
-          AcquisitionCostsTestDataItem.jsoupDoc.getElementsByTag("h1").text shouldEqual Messages("calc.base.pageHeading")
-        }
-
-        "have a monetary field that" should {
-
-          "have the title 'How much did you pay in costs when you became the property owner?'" in {
-            AcquisitionCostsTestDataItem.jsoupDoc.select("label[for=acquisitionCosts]").text shouldEqual Messages("calc.acquisitionCosts.question")
-          }
-
-          "have the help text 'Costs include agent fees, legal fees and surveys'" in {
-            AcquisitionCostsTestDataItem.jsoupDoc.select("span.form-hint").text shouldEqual Messages("calc.acquisitionCosts.helpText")
-          }
-
-          "have an input box for the acquisition costs" in {
-            AcquisitionCostsTestDataItem.jsoupDoc.getElementById("acquisitionCosts").tagName shouldBe "input"
-          }
-        }
-
-        "have a continue button that" should {
-
-          "be a button element" in {
-            AcquisitionCostsTestDataItem.jsoupDoc.getElementById("continue-button").tagName shouldBe "button"
-          }
-
-          "have the text 'Continue'" in {
-            AcquisitionCostsTestDataItem.jsoupDoc.getElementById("continue-button").text shouldEqual Messages("calc.base.continue")
-          }
+        "have the text 'Continue'" in {
+          DisposalCostsTestDataItem.jsoupDoc.getElementById("continue-button").text shouldEqual Messages("calc.base.continue")
         }
       }
     }
+  }
 
-    //################### Disposal Costs tests #######################
-    "In CalculationController calling the .disposalCosts action " should {
+  //################### Entrepreneurs Relief tests #######################
+  "In CalculationController calling the .entrepreneursRelief action " should {
 
-      object DisposalCostsTestDataItem extends fakeRequestTo("disposal-costs", CalculationController.disposalCosts)
+    object EntrepreneursReliefTestDataItem extends fakeRequestTo("entrepreneurs-relief", CalculationController.entrepreneursRelief)
 
-      "return a 200" in {
-        status(DisposalCostsTestDataItem.result) shouldBe 200
-      }
-
-      "return some HTML that" should {
-
-        "contain some text and use the character set utf-8" in {
-          contentType(DisposalCostsTestDataItem.result) shouldBe Some("text/html")
-          charset(DisposalCostsTestDataItem.result) shouldBe Some("utf-8")
-        }
-
-        "have the title 'How much did you pay in costs when you stopped being the property owner?'" in {
-          DisposalCostsTestDataItem.jsoupDoc.getElementsByTag("title").text shouldBe Messages("calc.disposalCosts.question")
-        }
-
-        "have a back link" in {
-          DisposalCostsTestDataItem.jsoupDoc.getElementById("link-back").text shouldEqual Messages("calc.base.back")
-        }
-
-        "have the heading 'Calculate your tax (non-residents)'" in {
-          DisposalCostsTestDataItem.jsoupDoc.getElementsByTag("h1").text shouldEqual Messages("calc.base.pageHeading")
-        }
-
-        "have a monetary field that" should {
-
-          "have the title 'How much did you pay in costs when you became the property owner?'" in {
-            DisposalCostsTestDataItem.jsoupDoc.select("label[for=disposalCosts]").text shouldEqual Messages("calc.disposalCosts.question")
-          }
-
-          "have an input box for the disposal costs" in {
-            DisposalCostsTestDataItem.jsoupDoc.getElementById("disposalCosts").tagName shouldBe "input"
-          }
-        }
-
-        "have a continue button that" should {
-
-          "be a button element" in {
-            DisposalCostsTestDataItem.jsoupDoc.getElementById("continue-button").tagName shouldBe "button"
-          }
-
-          "have the text 'Continue'" in {
-            DisposalCostsTestDataItem.jsoupDoc.getElementById("continue-button").text shouldEqual Messages("calc.base.continue")
-          }
-        }
-      }
+    "return a 200" in {
+      status(EntrepreneursReliefTestDataItem.result) shouldBe 200
     }
 
-    //################### Entrepreneurs Relief tests #######################
-    "In CalculationController calling the .entrepreneursRelief action " should {
+    "return some HTML that" should {
 
-      object EntrepreneursReliefTestDataItem extends fakeRequestTo("entrepreneurs-relief", CalculationController.entrepreneursRelief)
-
-      "return a 200" in {
-        status(EntrepreneursReliefTestDataItem.result) shouldBe 200
+      "contain some text and use the character set utf-8" in {
+        contentType(EntrepreneursReliefTestDataItem.result) shouldBe Some("text/html")
+        charset(EntrepreneursReliefTestDataItem.result) shouldBe Some("utf-8")
       }
 
-      "return some HTML that" should {
-
-        "contain some text and use the character set utf-8" in {
-          contentType(EntrepreneursReliefTestDataItem.result) shouldBe Some("text/html")
-          charset(EntrepreneursReliefTestDataItem.result) shouldBe Some("utf-8")
-        }
-
-        "have the title 'Are you claiming Entrepreneurs Relief?'" in {
-          EntrepreneursReliefTestDataItem.jsoupDoc.title shouldEqual Messages("calc.entrepreneursRelief.question")
-        }
-
-        "have the heading Calculate your tax (non-residents) " in {
-          EntrepreneursReliefTestDataItem.jsoupDoc.body.getElementsByTag("h1").text shouldEqual Messages("calc.base.pageHeading")
-        }
-
-        "have a 'Back' link " in {
-          EntrepreneursReliefTestDataItem.jsoupDoc.body.getElementById("link-back").text shouldEqual Messages("calc.base.back")
-        }
-
-        "have the question 'Are you claiming Entrepreneurs Relief?' as the legend of the input" in {
-          EntrepreneursReliefTestDataItem.jsoupDoc.body.getElementsByTag("legend").text shouldEqual Messages("calc.entrepreneursRelief.question")
-        }
-
-        "display a 'Continue' button " in {
-          EntrepreneursReliefTestDataItem.jsoupDoc.body.getElementById("continue-button").text shouldEqual Messages("calc.base.continue")
-        }
-
-        "have a sidebar with additional links" in {
-          EntrepreneursReliefTestDataItem.jsoupDoc.body.getElementsByClass("sidebar")
-        }
-
+      "have the title 'Are you claiming Entrepreneurs Relief?'" in {
+        EntrepreneursReliefTestDataItem.jsoupDoc.title shouldEqual Messages("calc.entrepreneursRelief.question")
       }
+
+      "have the heading Calculate your tax (non-residents) " in {
+        EntrepreneursReliefTestDataItem.jsoupDoc.body.getElementsByTag("h1").text shouldEqual Messages("calc.base.pageHeading")
+      }
+
+      "have a 'Back' link " in {
+        EntrepreneursReliefTestDataItem.jsoupDoc.body.getElementById("link-back").text shouldEqual Messages("calc.base.back")
+      }
+
+      "have the question 'Are you claiming Entrepreneurs Relief?' as the legend of the input" in {
+        EntrepreneursReliefTestDataItem.jsoupDoc.body.getElementsByTag("legend").text shouldEqual Messages("calc.entrepreneursRelief.question")
+      }
+
+      "display a 'Continue' button " in {
+        EntrepreneursReliefTestDataItem.jsoupDoc.body.getElementById("continue-button").text shouldEqual Messages("calc.base.continue")
+      }
+
+      "have a sidebar with additional links" in {
+        EntrepreneursReliefTestDataItem.jsoupDoc.body.getElementsByClass("sidebar")
+      }
+
+    }
+  }
+
+
+  //################### Allowable Losses tests #######################
+  "In CalculationController calling the .allowableLosses action " should {
+
+    object AllowableLossesTestDataItem extends fakeRequestTo("allowable-losses", CalculationController.allowableLosses)
+
+    "return a 200" in {
+      status(AllowableLossesTestDataItem.result) shouldBe 200
     }
 
+    "return some HTML that" should {
 
-    //################### Allowable Losses tests #######################
-    "In CalculationController calling the .allowableLosses action " should {
-
-      object AllowableLossesTestDataItem extends fakeRequestTo("allowable-losses", CalculationController.allowableLosses)
-
-      "return a 200" in {
-        status(AllowableLossesTestDataItem.result) shouldBe 200
+      "contain some text and use the character set utf-8" in {
+        contentType(AllowableLossesTestDataItem.result) shouldBe Some("text/html")
+        charset(AllowableLossesTestDataItem.result) shouldBe Some("utf-8")
       }
 
-      "return some HTML that" should {
+      "have a back button" in {
+        AllowableLossesTestDataItem.jsoupDoc.body.getElementById("link-back").text shouldEqual Messages("calc.base.back")
+      }
 
-        "contain some text and use the character set utf-8" in {
-          contentType(AllowableLossesTestDataItem.result) shouldBe Some("text/html")
-          charset(AllowableLossesTestDataItem.result) shouldBe Some("utf-8")
-        }
+      "have the title 'Are you claiming any allowable losses?'" in {
+        AllowableLossesTestDataItem.jsoupDoc.title shouldEqual Messages("calc.allowableLosses.question.one")
+      }
 
-        "have a back button" in {
-          AllowableLossesTestDataItem.jsoupDoc.body.getElementById("link-back").text shouldEqual Messages("calc.base.back")
-        }
+      "have the heading 'Calculate your tax (non-residents)'" in {
+        AllowableLossesTestDataItem.jsoupDoc.body.getElementsByTag("H1").text shouldEqual Messages("calc.base.pageHeading")
+      }
 
-        "have the title 'Are you claiming any allowable losses?'" in {
-          AllowableLossesTestDataItem.jsoupDoc.title shouldEqual Messages("calc.allowableLosses.question.one")
-        }
+      "have a yes no helper with hidden content and question 'Are you claiming any allowable losses?'" in {
+        AllowableLossesTestDataItem.jsoupDoc.body.getElementById("allowableLossesYes").parent.text shouldBe Messages("calc.base.yes")
+        AllowableLossesTestDataItem.jsoupDoc.body.getElementById("allowableLossesNo").parent.text shouldBe Messages("calc.base.no")
+        AllowableLossesTestDataItem.jsoupDoc.body.getElementsByTag("legend").text shouldBe Messages("calc.allowableLosses.question.one")
+      }
 
-        "have the heading 'Calculate your tax (non-residents)'" in {
-          AllowableLossesTestDataItem.jsoupDoc.body.getElementsByTag("H1").text shouldEqual Messages("calc.base.pageHeading")
-        }
+      "have a hidden monetary input with question 'Whats the total value of your allowable losses?'" in {
+        AllowableLossesTestDataItem.jsoupDoc.body.getElementById("allowableLosses").tagName shouldEqual "input"
+        AllowableLossesTestDataItem.jsoupDoc.select("label[for=allowableLosses]").text shouldEqual Messages("calc.allowableLosses.question.two")
+      }
 
-        "have a yes no helper with hidden content and question 'Are you claiming any allowable losses?'" in {
-          AllowableLossesTestDataItem.jsoupDoc.body.getElementById("allowableLossesYes").parent.text shouldBe Messages("calc.base.yes")
-          AllowableLossesTestDataItem.jsoupDoc.body.getElementById("allowableLossesNo").parent.text shouldBe Messages("calc.base.no")
-          AllowableLossesTestDataItem.jsoupDoc.body.getElementsByTag("legend").text shouldBe Messages("calc.allowableLosses.question.one")
-        }
+      "have a hidden help text section with summary 'What are allowable losses?' and correct content" in {
+        AllowableLossesTestDataItem.jsoupDoc.select("div#allowableLossesHiddenHelp").text should
+          include(Messages("calc.allowableLosses.helpText.title"))
+          include(Messages("calc.allowableLosses.helpText.paragraph.one"))
+          include(Messages("calc.allowableLosses.helpText.bullet.one"))
+          include(Messages("calc.allowableLosses.helpText.bullet.two"))
+          include(Messages("calc.allowableLosses.helpText.bullet.three"))
+      }
 
-        "have a hidden monetary input with question 'Whats the total value of your allowable losses?'" in {
-          AllowableLossesTestDataItem.jsoupDoc.body.getElementById("allowableLosses").tagName shouldEqual "input"
-          AllowableLossesTestDataItem.jsoupDoc.select("label[for=allowableLosses]").text shouldEqual Messages("calc.allowableLosses.question.two")
-        }
-
-        "have a hidden help text section with summary 'What are allowable losses?' and correct content" in {
-          AllowableLossesTestDataItem.jsoupDoc.select("div#allowableLossesHiddenHelp").text should
-            include(Messages("calc.allowableLosses.helpText.title"))
-            include(Messages("calc.allowableLosses.helpText.paragraph.one"))
-            include(Messages("calc.allowableLosses.helpText.bullet.one"))
-            include(Messages("calc.allowableLosses.helpText.bullet.two"))
-            include(Messages("calc.allowableLosses.helpText.bullet.three"))
-        }
-
-        "has a Continue button" in {
-          AllowableLossesTestDataItem.jsoupDoc.body.getElementById("continue-button").text shouldEqual Messages("calc.base.continue")
-        }
+      "has a Continue button" in {
+        AllowableLossesTestDataItem.jsoupDoc.body.getElementById("continue-button").text shouldEqual Messages("calc.base.continue")
       }
     }
+  }
 
 
-    //################### Other Reliefs tests #######################
-    "In CalculationController calling the .otherReliefs action " should {
+  //################### Other Reliefs tests #######################
+  "In CalculationController calling the .otherReliefs action " should {
 
-      object OtherReliefsTestDataItem extends fakeRequestTo("other-reliefs", CalculationController.otherReliefs)
+    object OtherReliefsTestDataItem extends fakeRequestTo("other-reliefs", CalculationController.otherReliefs)
 
-      "return a 200" in {
-        status(OtherReliefsTestDataItem.result) shouldBe 200
-      }
-
-      "return some HTML that" should {
-
-        "contain some text and use the character set utf-8" in {
-          contentType(OtherReliefsTestDataItem.result) shouldBe Some("text/html")
-          charset(OtherReliefsTestDataItem.result) shouldBe Some("utf-8")
-        }
-        "have the title 'How much extra tax relief are you claiming?'" in {
-          OtherReliefsTestDataItem.jsoupDoc.title shouldEqual Messages("calc.otherReliefs.question")
-        }
-
-        "have the heading Calculate your tax (non-residents) " in {
-          OtherReliefsTestDataItem.jsoupDoc.body.getElementsByTag("h1").text shouldEqual Messages("calc.base.pageHeading")
-        }
-
-        "have a 'Back' link " in {
-          OtherReliefsTestDataItem.jsoupDoc.body.getElementById("link-back").text shouldEqual Messages("calc.base.back")
-        }
-
-        "have the question 'How much extra tax relief are you claiming?' as the legend of the input" in {
-          OtherReliefsTestDataItem.jsoupDoc.body.getElementsByTag("label").text shouldEqual Messages("calc.otherReliefs.question")
-        }
-
-        "display an input box for the Other Tax Reliefs" in {
-          OtherReliefsTestDataItem.jsoupDoc.body.getElementById("otherReliefs").tagName() shouldEqual "input"
-        }
-
-        "display a 'Continue' button " in {
-          OtherReliefsTestDataItem.jsoupDoc.body.getElementById("continue-button").text shouldEqual Messages("calc.base.continue")
-        }
-      }
+    "return a 200" in {
+      status(OtherReliefsTestDataItem.result) shouldBe 200
     }
 
-    //################### Summary tests #######################
-    "In CalculationController calling the .summary action " should {
+    "return some HTML that" should {
 
-      object SummaryTestDataItem extends fakeRequestTo("summary", CalculationController.summary)
-
-      "return a 200" in {
-        status(SummaryTestDataItem.result) shouldBe 200
+      "contain some text and use the character set utf-8" in {
+        contentType(OtherReliefsTestDataItem.result) shouldBe Some("text/html")
+        charset(OtherReliefsTestDataItem.result) shouldBe Some("utf-8")
+      }
+      "have the title 'How much extra tax relief are you claiming?'" in {
+        OtherReliefsTestDataItem.jsoupDoc.title shouldEqual Messages("calc.otherReliefs.question")
       }
 
-      "return some HTML that" should {
+      "have the heading Calculate your tax (non-residents) " in {
+        OtherReliefsTestDataItem.jsoupDoc.body.getElementsByTag("h1").text shouldEqual Messages("calc.base.pageHeading")
+      }
 
-        "contain some text and use the character set utf-8" in {
-          contentType(SummaryTestDataItem.result) shouldBe Some("text/html")
-          charset(SummaryTestDataItem.result) shouldBe Some("utf-8")
-        }
+      "have a 'Back' link " in {
+        OtherReliefsTestDataItem.jsoupDoc.body.getElementById("link-back").text shouldEqual Messages("calc.base.back")
+      }
+
+      "have the question 'How much extra tax relief are you claiming?' as the legend of the input" in {
+        OtherReliefsTestDataItem.jsoupDoc.body.getElementsByTag("label").text shouldEqual Messages("calc.otherReliefs.question")
+      }
+
+      "display an input box for the Other Tax Reliefs" in {
+        OtherReliefsTestDataItem.jsoupDoc.body.getElementById("otherReliefs").tagName() shouldEqual "input"
+      }
+
+      "display a 'Continue' button " in {
+        OtherReliefsTestDataItem.jsoupDoc.body.getElementById("continue-button").text shouldEqual Messages("calc.base.continue")
+      }
+    }
+  }
+
+  //################### Summary tests #######################
+  "In CalculationController calling the .summary action " should {
+
+    object SummaryTestDataItem extends fakeRequestTo("summary", CalculationController.summary)
+
+    "return a 200" in {
+      status(SummaryTestDataItem.result) shouldBe 200
+    }
+
+    "return some HTML that" should {
+
+      "contain some text and use the character set utf-8" in {
+        contentType(SummaryTestDataItem.result) shouldBe Some("text/html")
+        charset(SummaryTestDataItem.result) shouldBe Some("utf-8")
       }
     }
   }


### PR DESCRIPTION
**Note**
This includes a copy of the GovUK helper `inputRadioGroup` that has been called `formInputRadioGroup`. This has been done to introduce help text.

My intention is to fork ASSETS_FRONTEND and then raise a PR to add in the enhancement to the main helper in GovUK - the we can switch to using that helper instead.