### PR TITLE
CGT-656: A large number of changes to markup, styling, error handling

### DIFF
--- a/app/forms/DisposalCostsForm.scala
+++ b/app/forms/DisposalCostsForm.scala
@@ -25,9 +25,9 @@ import play.api.i18n.Messages
 object DisposalCostsForm {
   val disposalCostsForm = Form(
     mapping(
-      "disposalCosts" -> bigDecimal
-        .verifying(Messages("calc.disposalCosts.errorNegativeNumber"), disposalCosts => isPositive(disposalCosts))
-        .verifying(Messages("calc.disposalCosts.errorDecimalPlaces"), disposalCosts => isMaxTwoDecimalPlaces(disposalCosts))
+      "disposalCosts" -> optional(bigDecimal)
+        .verifying(Messages("calc.disposalCosts.errorNegativeNumber"), disposalCosts => isPositive(disposalCosts.getOrElse(0)))
+        .verifying(Messages("calc.disposalCosts.errorDecimalPlaces"), disposalCosts => isMaxTwoDecimalPlaces(disposalCosts.getOrElse(0)))
     )(DisposalCostsModel.apply)(DisposalCostsModel.unapply)
   )
 }

--- a/app/forms/ImprovementsForm.scala
+++ b/app/forms/ImprovementsForm.scala
@@ -24,15 +24,24 @@ import common.Validation._
 
 object ImprovementsForm {
 
-  def verify(data: ImprovementsModel): Option[ImprovementsModel] = {
+  def verifyAmountSupplied(data: ImprovementsModel): Boolean = {
     data.isClaimingImprovements match {
-      case "Yes" =>
-        if (data.improvementsAmt.isDefined) {
-          Option(ImprovementsModel(data.isClaimingImprovements, data.improvementsAmt))
-        } else {
-          None
-        }
-      case "No" => Option(ImprovementsModel(data.isClaimingImprovements, None))
+      case "Yes" => data.improvementsAmt.isDefined
+      case "No" => true
+    }
+  }
+
+  def verifyPositive(data: ImprovementsModel): Boolean = {
+    data.isClaimingImprovements match {
+      case "Yes" => isPositive(data.improvementsAmt.getOrElse(0))
+      case "No" => true
+    }
+  }
+
+  def verifyTwoDecimalPlaces(data: ImprovementsModel): Boolean = {
+    data.isClaimingImprovements match {
+      case "Yes" => isMaxTwoDecimalPlaces(data.improvementsAmt.getOrElse(0))
+      case "No" => true
     }
   }
 
@@ -40,11 +49,12 @@ object ImprovementsForm {
     mapping(
       "isClaimingImprovements" -> text,
       "improvementsAmt" -> optional(bigDecimal)
-        .verifying(Messages("calc.improvements.errorNegative"), improvementsAmt => isPositive(improvementsAmt.getOrElse(0)))
-        .verifying(Messages("calc.improvements.errorDecimalPlaces"), improvementsAmt => isMaxTwoDecimalPlaces(improvementsAmt.getOrElse(0)))
     )(ImprovementsModel.apply)(ImprovementsModel.unapply)
-      .verifying(
-        Messages("calc.improvements.error.no.value.supplied"),
-        improvementsForm => verify(ImprovementsModel(improvementsForm.isClaimingImprovements, improvementsForm.improvementsAmt)).isDefined)
+      .verifying(Messages("calc.improvements.error.no.value.supplied"),
+        improvementsForm => verifyAmountSupplied(ImprovementsModel(improvementsForm.isClaimingImprovements, improvementsForm.improvementsAmt)))
+      .verifying(Messages("calc.improvements.errorNegative"),
+        improvementsForm => verifyPositive(improvementsForm))
+      .verifying(Messages("calc.improvements.errorDecimalPlaces"),
+        improvementsForm => verifyTwoDecimalPlaces(improvementsForm))
   )
 }

--- a/app/models/DisposalCostsModel.scala
+++ b/app/models/DisposalCostsModel.scala
@@ -18,7 +18,7 @@ package models
 
 import play.api.libs.json.Json
 
-case class DisposalCostsModel (disposalCosts: BigDecimal)
+case class DisposalCostsModel (disposalCosts: Option[BigDecimal])
 
 object DisposalCostsModel {
   implicit val format = Json.format[DisposalCostsModel]

--- a/app/views/calculation/acquisitionCosts.scala.html
+++ b/app/views/calculation/acquisitionCosts.scala.html
@@ -6,7 +6,7 @@
 
 @main_template(Messages("calc.acquisitionCosts.question")) {
 
-    <a id="link-back" class="link-back" href="#">@Messages("calc.base.back")</a>
+    <a id="back-link" class="back-link" href="#">@Messages("calc.base.back")</a>
 
     <h1 class="heading-large">@Messages("calc.base.pageHeading")</h1>
 

--- a/app/views/calculation/acquisitionValue.scala.html
+++ b/app/views/calculation/acquisitionValue.scala.html
@@ -7,7 +7,7 @@
 
 @main_template(Messages("calc.acquisitionValue.question")) {
 
-    <a id="link-back" class="link-back" href="#">@Messages("calc.base.back")</a>
+    <a id="back-link" class="back-link" href="#">@Messages("calc.base.back")</a>
 
     <h1 class="heading-large">@Messages("calc.base.pageHeading")</h1>
 

--- a/app/views/calculation/allowableLosses.scala.html
+++ b/app/views/calculation/allowableLosses.scala.html
@@ -5,7 +5,7 @@
 @(allowableLossesForm: Form[AllowableLossesModel])(implicit request: Request[_])
 
 @hiddenYesNoContent = {
-    @simpleNoErrorInput(allowableLossesForm("allowableLossesAmt"), '_label -> Messages("calc.allowableLosses.question.two"), '_dataAttributes -> "placeholder = £")
+    @formInputMoney(allowableLossesForm, "allowableLossesAmt", Messages("calc.allowableLosses.question.two"))
 }
 
 @hiddenHelpTextContent = {
@@ -19,13 +19,18 @@
 
 @main_template(Messages("calc.allowableLosses.question.one")) {
 
-    <a id="link-back" class="link-back" href="@routes.CalculationController.entrepreneursRelief">Back</a>
+    <a id="back-link" class="back-link" href="@routes.CalculationController.entrepreneursRelief">Back</a>
 
     <h1 class="heading-large">@Messages("calc.base.pageHeading")</h1>
 
     @govHelpers.form(action = routes.CalculationController.submitAllowableLosses) {
 
-        @formHiddenYesNoRadio(allowableLossesForm,"isClaimingAllowableLosses",Messages("calc.allowableLosses.question.one"),hiddenYesNoContent)
+        @formHiddenYesNoRadio(
+            allowableLossesForm,
+            "isClaimingAllowableLosses",
+            Messages("calc.allowableLosses.question.one"),
+            hiddenYesNoContent
+        )
 
         @hiddenHelpText("allowableLossesHiddenHelp",Messages("calc.allowableLosses.helpText.title"),hiddenHelpTextContent)
 

--- a/app/views/calculation/annualExemptAmount.scala.html
+++ b/app/views/calculation/annualExemptAmount.scala.html
@@ -12,7 +12,7 @@
 
 @main_template(Messages("calc.annualExemptAmount.question"), sidebarLinks = Some(sidebar)) {
 
-    <a id="link-back" class="link-back" href="@routes.CalculationController.otherProperties">Back</a>
+    <a id="back-link" class="back-link" href="@routes.CalculationController.otherProperties">Back</a>
 
     <h1 class="heading-large">@Messages("calc.base.pageHeading")</h1>
 

--- a/app/views/calculation/currentIncome.scala.html
+++ b/app/views/calculation/currentIncome.scala.html
@@ -1,19 +1,26 @@
 @import models.CurrentIncomeModel
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 @import play.api.data._
+@import views.html.helpers._
 
 @(currentIncomeForm: Form[CurrentIncomeModel])(implicit request: Request[_])
 
-@import views.html.helpers._
-
 @sidebar = {
-    <a id="helpLink1" href="https://www.gov.uk/income-tax/overview">@Messages("calc.currentIncome.link.one")</a>
-    <a id="helpLink2" href="https://www.gov.uk/income-tax-rates/previous-tax-years">@Messages("calc.currentIncome.link.two")</a>
+    <ul>
+        <li>
+            <a id="helpLink1" href="https://www.gov.uk/income-tax/overview">@Messages("calc.currentIncome.link.one")</a>
+        </li>
+    </ul>
+    <ul>
+        <li>
+            <a id="helpLink2" href="https://www.gov.uk/income-tax-rates/previous-tax-years">@Messages("calc.currentIncome.link.two")</a>
+        </li>
+    </ul>
 }
 
 @main_template(Messages("calc.currentIncome.question"), sidebarLinks = Some(sidebar)) {
 
-    <a id="link-back" class="link-back" href="@routes.CalculationController.customerType">Back</a>
+    <a id="back-link" class="back-link" href="@routes.CalculationController.customerType">Back</a>
 
     <h1 class="heading-large">@Messages("calc.base.pageHeading")</h1>
 

--- a/app/views/calculation/customerType.scala.html
+++ b/app/views/calculation/customerType.scala.html
@@ -1,26 +1,26 @@
 @import models.CustomerTypeModel
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 @import play.api.data._
+@import views.html.helpers._
 
 @(customerTypeForm: Form[CustomerTypeModel])(implicit request: Request[_])
 
 @main_template(title = Messages("calc.customerType.question")) {
 
-  <a id="link-back" class="link-back" href="@routes.IntroductionController.introduction">@Messages("calc.base.back")</a>
+  <a id="back-link" class="back-link" href="@routes.IntroductionController.introduction">@Messages("calc.base.back")</a>
 
   <h1 class="heading-large">@Messages("calc.base.pageHeading")</h1> 
 
   @govHelpers.form(action = routes.CalculationController.submitCustomerType) {
 
     <div class="form-group">
-        @govHelpers.inputRadioGroup(
+        @formInputRadioGroup(
             field = customerTypeForm("customerType"),
             Seq(
                 "individual"->Messages("calc.customerType.individual"),
                 "trustee"->Messages("calc.customerType.trustee"),
                 "personalRep"->Messages("calc.customerType.personalRep")),
             '_legend -> Messages("calc.customerType.question"),
-            '_labelAfter -> true,
             '_labelClass -> "block-label"
         )
     </div>

--- a/app/views/calculation/disabledTrustee.scala.html
+++ b/app/views/calculation/disabledTrustee.scala.html
@@ -7,7 +7,7 @@
 
 @main_template(Messages("calc.disabledTrustee.question")) {
 
-    <a id="link-back" class="link-back" href="@routes.CalculationController.customerType">Back</a>
+    <a id="back-link" class="back-link" href="@routes.CalculationController.customerType">Back</a>
 
     <h1 class="heading-large">@Messages("calc.base.pageHeading")</h1>
 

--- a/app/views/calculation/disposalCosts.scala.html
+++ b/app/views/calculation/disposalCosts.scala.html
@@ -5,7 +5,7 @@
 @(disposalCostsForm: Form[DisposalCostsModel])(implicit request: Request[_])
 
 @main_template(Messages("calc.disposalCosts.question")) {
-    <a id="link-back" class="link-back" href="@routes.CalculationController.otherProperties">Back</a>
+    <a id="back-link" class="back-link" href="@routes.CalculationController.otherProperties">Back</a>
     <h1 class="heading-large">@Messages("calc.base.pageHeading")</h1>
 
     @govHelpers.form(action = routes.CalculationController.submitDisposalCosts) {

--- a/app/views/calculation/disposalDate.scala.html
+++ b/app/views/calculation/disposalDate.scala.html
@@ -6,7 +6,7 @@
 
 @main_template(Messages("calc.disposalDate.question")) {
 
-    <a id="link-back" class="link-back" href="@routes.CalculationController.improvements">@Messages("calc.base.back")</a>
+    <a id="back-link" class="back-link" href="@routes.CalculationController.improvements">@Messages("calc.base.back")</a>
 
     <h1 class="heading-large">@Messages("calc.base.calculate.tax.heading")</h1>
 

--- a/app/views/calculation/disposalValue.scala.html
+++ b/app/views/calculation/disposalValue.scala.html
@@ -6,7 +6,7 @@
 @(disposalValueForm: Form[DisposalValueModel])(implicit request: Request[_])
 
 @main_template(Messages("calc.disposalValue.question")) {
-    <a id="link-back" class="link-back" href="@routes.CalculationController.improvements">@Messages("calc.base.back")</a>
+    <a id="back-link" class="back-link" href="@routes.CalculationController.improvements">@Messages("calc.base.back")</a>
     <h1 class="heading-large">@Messages("calc.base.calculate.tax.heading")</h1>
 
     @govHelpers.form(action = routes.CalculationController.submitDisposalValue) {

--- a/app/views/calculation/entrepreneursRelief.scala.html
+++ b/app/views/calculation/entrepreneursRelief.scala.html
@@ -10,21 +10,21 @@
 
 @main_template(Messages("calc.entrepreneursRelief.question"), sidebarLinks = Some(sidebar)) {
 
-    <a id="link-back" class="link-back" href="#">@Messages("calc.base.back")</a>
+    <a id="back-link" class="back-link" href="#">@Messages("calc.base.back")</a>
 
     <h1 class="heading-large">@Messages("calc.base.pageHeading")</h1>
 
     @govHelpers.form(action = routes.CalculationController.submitEntrepreneursRelief) {
 
     <div class="inline form-group">
-        @govHelpers.inputRadioGroup(
-        field = entrepreneursReliefForm("entrepreneursRelief"),
-        Seq(
-        "Yes"->Messages("calc.base.yes"),
-        "No"->Messages("calc.base.no")),
-        '_legend -> Messages("calc.entrepreneursRelief.question"),
-        '_labelAfter -> true,
-        '_labelClass -> "block-label"
+        @formInputRadioGroup(
+            field = entrepreneursReliefForm("entrepreneursRelief"),
+            Seq(
+                "Yes"->Messages("calc.base.yes"),
+                "No"->Messages("calc.base.no")),
+            '_legend -> Messages("calc.entrepreneursRelief.question"),
+            '_labelAfter -> true,
+            '_labelClass -> "block-label"
         )
 
     </div>

--- a/app/views/calculation/improvements.scala.html
+++ b/app/views/calculation/improvements.scala.html
@@ -19,10 +19,10 @@
             formInputMoney(
                 improvementsForm,
                 "improvementsAmt",
-                Messages("calc.improvements.questionTwo"),
-                Some(Messages("calc.improvements.help"))
-            )
-        )
+                Messages("calc.improvements.questionTwo")
+            ),
+            Some(Messages("calc.improvements.help"))
+)
 
         <button class="button" type="submit" id="continue-button">@Messages("calc.base.continue")</button>
     }

--- a/app/views/calculation/improvements.scala.html
+++ b/app/views/calculation/improvements.scala.html
@@ -5,12 +5,24 @@
 @(improvementsForm: Form[ImprovementsModel])(implicit request: Request[_])
 
 @main_template(Messages("calc.improvements.question")) {
-    <a id="link-back" class="link-back" href="#">@Messages("calc.base.back")</a>
+
+    <a id="back-link" class="back-link" href="#">@Messages("calc.base.back")</a>
+
     <h1 class="heading-large">@Messages("calc.base.pageHeading")</h1>
 
     @govHelpers.form(action = routes.CalculationController.submitImprovements) {
 
-        @formHiddenYesNoRadio(improvementsForm, "isClaimingImprovements", Messages("calc.improvements.question"), simpleNoErrorInput(improvementsForm("improvementsAmt"), '_label -> Messages("calc.improvements.questionTwo"), '_inputHint -> Option(Messages("calc.improvements.help")).getOrElse(""), '_dataAttributes -> "placeholder = £"))
+        @formHiddenYesNoRadio(
+            improvementsForm,
+            "isClaimingImprovements",
+            Messages("calc.improvements.question"),
+            formInputMoney(
+                improvementsForm,
+                "improvementsAmt",
+                Messages("calc.improvements.questionTwo"),
+                Some(Messages("calc.improvements.help"))
+            )
+        )
 
         <button class="button" type="submit" id="continue-button">@Messages("calc.base.continue")</button>
     }

--- a/app/views/calculation/otherProperties.scala.html
+++ b/app/views/calculation/otherProperties.scala.html
@@ -6,12 +6,12 @@
 
 @main_template(Messages("calc.otherProperties.question")) {
 
-    <a id="link-back" class="link-back" href="">@Messages("calc.base.back")</a>
+    <a id="back-link" class="back-link" href="">@Messages("calc.base.back")</a>
     <h1 class="heading-large">@Messages("calc.base.pageHeading")</h1>
 
     @govHelpers.form(action = routes.CalculationController.submitOtherProperties) {
         <div class="inline form-group">
-            @govHelpers.inputRadioGroup(
+            @formInputRadioGroup(
                 field = otherPropertiesForm("otherProperties"),
                 Seq(
                     "Yes"->Messages("calc.base.yes"),

--- a/app/views/calculation/otherReliefs.scala.html
+++ b/app/views/calculation/otherReliefs.scala.html
@@ -10,8 +10,18 @@
 
     @govHelpers.form(action = routes.CalculationController.submitOtherReliefs) {
 
-        @formInputMoney(otherReliefsForm, "otherReliefs", Messages("calc.otherReliefs.question"))
+        <label for="otherReliefs">@Messages("calc.otherReliefs.question")</label>
 
-        <button id="continue-button" class="button">@Messages("calc.base.button.continue")</button>
+        <div class="panel-indent">
+            <ul class="list list-bullet">
+                <li id="totalGain">£XXXX.pp<br><span class="font-xsmall">@Messages("calc.otherReliefs.totalGain")</span></li>
+
+                <li id="taxableGain">£XXXX.pp<br><span class="font-xsmall">@Messages("calc.otherReliefs.taxableGain")</span></li>
+            </ul>
+        </div>
+
+        @formInputMoney(otherReliefsForm, "otherReliefs", "")
+
+        <button id="add-relief-button" class="button">@Messages("calc.otherReliefs.button.addRelief")</button>
     }
 }

--- a/app/views/calculation/otherReliefs.scala.html
+++ b/app/views/calculation/otherReliefs.scala.html
@@ -5,7 +5,7 @@
 @(otherReliefsForm: Form[OtherReliefsModel])(implicit request: Request[_])
 
 @main_template(Messages("calc.otherReliefs.question")) {
-    <a id="link-back" class="link-back" href="@routes.CalculationController.allowableLosses">@Messages("calc.base.back")</a>
+    <a id="back-link" class="back-link" href="@routes.CalculationController.allowableLosses">@Messages("calc.base.back")</a>
     <h1 class="heading-large">@Messages("calc.base.calculate.tax.heading")</h1>
 
     @govHelpers.form(action = routes.CalculationController.submitOtherReliefs) {

--- a/app/views/calculation/personalAllowance.scala.html
+++ b/app/views/calculation/personalAllowance.scala.html
@@ -17,7 +17,7 @@
 
 @main_template(Messages("calc.personalAllowance.question"), sidebarLinks = Some(sidebar)) {
 
-    <a id="link-back" class="link-back" href="#">@Messages("calc.base.back")</a>
+    <a id="back-link" class="back-link" href="#">@Messages("calc.base.back")</a>
 
     <h1 class="heading-large">@Messages("calc.base.pageHeading")</h1>
 

--- a/app/views/govuk_wrapper.scala.html
+++ b/app/views/govuk_wrapper.scala.html
@@ -16,13 +16,17 @@
 @import views.html.helpers._
 
 @scriptElement = {
-<script type="text/javascript" src='@controllers.routes.Assets.at("javascripts/cgt.js")'></script>
+    <script type="text/javascript" src='@controllers.routes.Assets.at("javascripts/cgt.js")'></script>
+}
+
+@linksElement = {
+    <link rel="stylesheet" type="text/css" href='@controllers.routes.Assets.at("stylesheets/cgt.css")'>
 }
 
 @head = {
     @uiLayouts.head(
       assetsPrefix = appConfig.assetsPrefix,
-      linkElem = None,
+      linkElem = Some(linksElement),
       headScripts = None)
     <meta name="format-detection" content="telephone=no" />
 }

--- a/app/views/helpers/formHiddenYesNoRadio.scala.html
+++ b/app/views/helpers/formHiddenYesNoRadio.scala.html
@@ -1,7 +1,10 @@
+@import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
+
 @(form: Form[_], fieldName: String, questionText:String, content:Html, helpText:Option[String] = None)(implicit lang: play.api.i18n.Lang)
 
-@fieldsetClasses = @{if(form.hasErrors) "form-field-group--error fields-aligned" else "" }
-<div class="form-group @fieldsetClasses" data-hidden='hidden'>
+@hiddenClasses = @{if(form.errors.filter(_.key == "").length > 0) "form-field--error" else "" }
+
+<div class="form-group" data-hidden='hidden'>
 
     @formInputRadioGroup(
         field = form(fieldName),
@@ -16,7 +19,9 @@
         )
 
     <div class="panel-indent" id='hidden' style="display: none">
-        @form.errors.map { error => <span class="error-notification">@Messages(error.message)</span>}
-        @content
+        <div class="@hiddenClasses">
+            @form.errors.filter(_.key == "").map { error => <span class="error-notification">@Messages(error.message)</span>}
+            @content
+        </div>
     </div>
 </div>

--- a/app/views/helpers/formInlineDateInput.scala.html
+++ b/app/views/helpers/formInlineDateInput.scala.html
@@ -6,7 +6,7 @@
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 @import java.text.SimpleDateFormat
 
-@fieldsetClasses = @{if(formItem.hasErrors) "form-field--error fields-aligned" else "" }
+@fieldsetClasses = @{if(formItem.hasErrors) "form-field--error" else "" }
 
 @dayErrorClass = @{if(formItem(s"${fieldName}.day").hasErrors) "error-field" else "" }
 @monthErrorClass = @{if(formItem(s"${fieldName}.month").hasErrors) "error-field" else "" }
@@ -16,7 +16,7 @@
 
     @formItem.errors.map { error => <span class="error-notification">@Messages(error.message)</span>}
 
-    <legend>@questionText</legend>
+    @questionText
 
     <span class="form-hint">@Messages("calc.common.date.hint")</span>
 

--- a/app/views/helpers/formInputMoney.scala.html
+++ b/app/views/helpers/formInputMoney.scala.html
@@ -4,6 +4,16 @@
 
 @(inputForm: Form[_], fieldName: String, questionText: String, helpText: Option[String] = None)(implicit lang: play.api.i18n.Lang)
 
+    <style>
+
+    </style>
+
     <div class="form-group">
-        @govHelpers.input(inputForm(fieldName), '_label -> questionText, '_inputHint -> helpText.getOrElse(""), '_dataAttributes -> "placeholder = £")
+        @moneyInputFormat(
+            inputForm(fieldName),
+            '_label -> questionText,
+            '_inputHint -> helpText.getOrElse(""),
+            '_type -> "number",
+            '_inputClass -> "input--no-spinner"
+        )
     </div>

--- a/app/views/helpers/formInputRadioGroup.scala.html
+++ b/app/views/helpers/formInputRadioGroup.scala.html
@@ -19,55 +19,57 @@
 @import views.html.helper._
 
 @elements = @{new FieldElements(field.id, field, null, args.toMap, lang) }
-@fieldsetClass = {@elements.args.get('_groupClass)@if(elements.hasErrors){ form-field--error}}
+@fieldsetClass = {@elements.args.get('_groupClass)}
 @labelAfter = @{ elements.args.get('_labelAfter).getOrElse(false).asInstanceOf[Boolean] }
-<fieldset class="@fieldsetClass"
-    @if(elements.args.get('_fieldsetAttributes).isDefined) {@elements.args.get('_fieldsetAttributes)}>
-    @if(elements.args.get('_legend).isDefined) {
-        <legend @if(elements.args.get('_legendClass).isDefined) {class="@elements.args.get('_legendClass)"}>
-            @elements.args.get('_legend)
-        </legend>
-    }
-    @if(elements.args.get('_helpText).isDefined) {
-        <span class="form-hint">
-            @elements.args.get('_helpText)
-        </span>
-    }
-    @elements.errors.map{error => <span class="error-notification">@Messages(error)</span>}
-
-    @radioOptions.map { case (value, label) =>
-        @defining(s"${elements.field.name}-${value.toLowerCase.replace(" ","_")}")  { inputId =>
-            <label for="@inputId"
-               @elements.args.get('_labelClass).map{labelClass => class="@labelClass@field.value.filter( _ == value).map{_ => selected}"}>
-                @if(!labelAfter) {
-                    @if(elements.args.get('_stackedLabel)) {
-                        @if(label.split(" ").length < 2) {<br>@label
-                            } else {
-                                @for( (l, index) <- label.split(" ").zipWithIndex) {
-                                @if(index != 0) {<br>}@l
-                            }
-                        }
-                    } else { @label }
-                }
-                <input
-                    type="radio"
-                    id="@inputId"
-                    name="@elements.field.name"
-                    value="@value"
-                    @elements.args.get('_inputClass).map{inputClass => class="@inputClass"}
-                    @if(elements.args.contains('_dataAttributes) ){ @elements.args.get('_dataAttributes)}
-                    @field.value.filter( _ == value).map{_ => checked="checked"}/>
-                @if(labelAfter) {
-                    @if(elements.args.get('_stackedLabel)) {
-                        @if(label.split(" ").length < 2) {<br>@label
-                            } else {
-                                @for( (l, index) <- label.split(" ").zipWithIndex) {
-                                @if(index != 0) {<br>}@l
-                            }
-                        }
-                    } else { @label }
-                }
-            </label>
+<div class="@if(elements.hasErrors){ form-field--error}">
+    <fieldset class="@fieldsetClass"
+        @if(elements.args.get('_fieldsetAttributes).isDefined) {@elements.args.get('_fieldsetAttributes)}>
+        @if(elements.args.get('_legend).isDefined) {
+            <legend @if(elements.args.get('_legendClass).isDefined) {class="@elements.args.get('_legendClass)"}>
+                @elements.args.get('_legend)
+            </legend>
         }
-    }
-</fieldset>
+        @if(elements.args.get('_helpText).isDefined) {
+            <span class="form-hint">
+                @elements.args.get('_helpText)
+            </span>
+        }
+        @elements.errors.map{error => <span class="error-notification">@Messages(error)</span>}
+
+        @radioOptions.map { case (value, label) =>
+            @defining(s"${elements.field.name}-${value.toLowerCase.replace(" ","_")}")  { inputId =>
+                <label for="@inputId"
+                   @elements.args.get('_labelClass).map{labelClass => class="@labelClass@field.value.filter( _ == value).map{_ => selected}"}>
+                    @if(!labelAfter) {
+                        @if(elements.args.get('_stackedLabel)) {
+                            @if(label.split(" ").length < 2) {<br>@label
+                                } else {
+                                    @for( (l, index) <- label.split(" ").zipWithIndex) {
+                                    @if(index != 0) {<br>}@l
+                                }
+                            }
+                        } else { @label }
+                    }
+                    <input
+                        type="radio"
+                        id="@inputId"
+                        name="@elements.field.name"
+                        value="@value"
+                        @elements.args.get('_inputClass).map{inputClass => class="@inputClass"}
+                        @if(elements.args.contains('_dataAttributes) ){ @elements.args.get('_dataAttributes)}
+                        @field.value.filter( _ == value).map{_ => checked="checked"}/>
+                    @if(labelAfter) {
+                        @if(elements.args.get('_stackedLabel)) {
+                            @if(label.split(" ").length < 2) {<br>@label
+                                } else {
+                                    @for( (l, index) <- label.split(" ").zipWithIndex) {
+                                    @if(index != 0) {<br>}@l
+                                }
+                            }
+                        } else { @label }
+                    }
+                </label>
+            }
+        }
+    </fieldset>
+</div>

--- a/app/views/helpers/moneyInputFormat.scala.html
+++ b/app/views/helpers/moneyInputFormat.scala.html
@@ -1,0 +1,94 @@
+@*
+* Copyright 2015 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
+@(field: play.api.data.Field, args: (Symbol,Any)*)(implicit lang: play.api.i18n.Lang)
+
+@import play.api.i18n._
+@import views.html.helper._
+
+
+@elements = @{ new FieldElements(field.id, field, null, args.toMap, lang) }
+@parentField = @{args.toMap.get('parentField).asInstanceOf[Option[Field]]}
+@parentElements = @{parentField.map(pf => new FieldElements(pf.id, pf, null, Map(), lang) )}
+@value = @{ field.value match { case Some(x) => x case None => "" case x => x }}
+@labelAfter = @{ elements.args.get('_labelAfter).getOrElse(false).asInstanceOf[Boolean] }
+@labelHighlight = @{ elements.args.get('_labelHighlight).getOrElse(false).asInstanceOf[Boolean] }
+
+
+<label for="@elements.field.name" class="@elements.args.get('_divClass) @if( elements.args.get('_labelClass) ){ @elements.args.get('_labelClass) } @if(elements.hasErrors || (parentElements.isDefined && parentElements.get.hasErrors)) {form-field--error}" @if(elements.args.contains('_labelDataAttributes)){@elements.args.get('_labelDataAttributes)}>
+
+    @if(!elements.args.contains('_hideErrors)) {
+        @elements.errors.map { error =>
+            <span class="error-notification"
+                @if(elements.args.contains('_error_id)) {
+                    id="@elements.args.get('_error_id)"
+                }
+                role="tooltip"
+                data-journey="search-page:error:@elements.field.name">
+                @Messages(error)
+            </span>
+        }
+    }
+
+    @if(parentElements.isDefined) {
+        @parentElements.get.errors.map { error => <span class="error-notification">@Messages(error)</span>}
+    }
+
+    @if(!labelAfter && elements.args.contains('_label)) {
+        @if(labelHighlight){<strong>}
+        <span @if(elements.args.contains('_labelTextClass)) { class="@elements.args.get('_labelTextClass)"}>
+            @elements.label
+        </span>
+        @if(elements.args.contains('_inputHint) ){
+            <span class="form-hint"
+                @if(elements.args.contains('_hintId)) {
+                    id="@elements.args.get('_hintId)"
+            }>
+                @elements.args.get('_inputHint)
+            </span>
+        }
+        @if(labelHighlight){</strong>}
+    }
+
+    <span class="poundSign">&pound;</span>
+    <input
+        @if( elements.args.contains('_type)){type="@elements.args.get('_type)" }else{type="text" }
+        @if( elements.args.contains('_dataAttributes) ){ @elements.args.get('_dataAttributes)}
+        class="moneyField @if( elements.args.get('_inputClass) ){ @elements.args.get('_inputClass) }"
+        @if( elements.args.get('_autoComplete) ){ autocomplete="@elements.args.get('_autoComplete)" }
+        name="@elements.field.name"
+        id="@elements.field.name"
+        value="@value"
+        step="0.01"
+        @if(elements.args.get('_error_id).isDefined) { aria-labeledby="@elements.args.get('_error_id)" }
+        @if(elements.args.get('_hintId).isDefined) { aria-describedby="@elements.args.get('_hintId)" }
+        @if(elements.args.get('_maxlength).isDefined) { maxlength="@elements.args.get('_maxlength)" }
+        @if(elements.args.get('_pattern).isDefined) { pattern="@elements.args.get('_pattern)" }
+        @if(elements.args.get('_title).isDefined) { title="@elements.args.get('_title)" }
+        @if(elements.args.get('_required).isDefined) { required }
+    />
+
+    @if(labelAfter && elements.args.contains('_label)) {
+        @if(labelHighlight){<strong>}
+        <span @if(elements.args.contains('_labelTextClass)) { class="@elements.args.get('_labelTextClass)"}>
+            @elements.label
+        </span>
+        @if(elements.args.contains('_inputHint) ){
+            <span class="form-hint">@elements.args.get('_inputHint)</span>
+        }
+        @if(labelHighlight){</strong>}
+    }
+
+</label>

--- a/app/views/helpers/simpleNoErrorInput.scala.html
+++ b/app/views/helpers/simpleNoErrorInput.scala.html
@@ -9,7 +9,6 @@
 @labelAfter = @{ elements.args.get('_labelAfter).getOrElse(false).asInstanceOf[Boolean] }
 @labelHighlight = @{ elements.args.get('_labelHighlight).getOrElse(false).asInstanceOf[Boolean] }
 
-
 <label for="@elements.field.name" class="@elements.args.get('_divClass) @if( elements.args.get('_labelClass) ){ @elements.args.get('_labelClass) }" @if(elements.args.contains('_labelDataAttributes)){@elements.args.get('_labelDataAttributes)}>
 
 @if(!labelAfter && elements.args.contains('_label)) {

--- a/app/views/introduction/intro.scala.html
+++ b/app/views/introduction/intro.scala.html
@@ -10,7 +10,7 @@
     <p>@Messages("calc.introduction.textOne")</p>
     <p>@Messages("calc.introduction.textTwo")</p>
 
-    <a id="start" href=@controllers.routes.CalculationController.customerType class="button button-start">@Messages("calc.introduction.start")</a>
+    <a id="start" href=@controllers.routes.CalculationController.customerType class="button button--get-started">@Messages("calc.introduction.start")</a>
 
     <h2 class="heading-medium">@Messages("calc.introduction.listOneTitle")</h2>
     <p>@Messages("calc.introduction.listOneText")</p>

--- a/app/views/main_template.scala.html
+++ b/app/views/main_template.scala.html
@@ -12,8 +12,10 @@
 @serviceInfoContent = {}
 
 @sidebarContent = {
-    <h2 class=heading-medium">@Messages("calc.common.readMore")</h2>
-    @sidebarLinks.get
+    <div class="service-info">
+        <h2 class=heading-medium">@Messages("calc.common.readMore")</h2>
+        @sidebarLinks.get
+    </div>
 }
 
 @sidebar = {

--- a/conf/messages
+++ b/conf/messages
@@ -1,9 +1,9 @@
 ## Base ##
-calc.base.pageHeading = Calculate your tax (non-residents)
+calc.base.pageHeading = Calculate your Capital Gains Tax
 calc.base.continue = Continue
 calc.base.taxStart = 6 April 2015
 calc.base.back = Back
-calc.base.calculate.tax.heading = Calculate your tax (non-residents)
+calc.base.calculate.tax.heading = Calculate your Capital Gains Tax
 calc.base.percentage.comp = complete
 calc.base.button.continue = Continue
 calc.base.yes = Yes
@@ -29,7 +29,7 @@ calc.common.invalidError = Invalid selection!
 calc.introduction.title = Introduction
 calc.introduction.header = Capital Gains Tax calculator for non-residents
 calc.introduction.lede = Capital Gains Tax for non-residents came into effect from
-calc.introduction.textOne = If you’ve made or lost money on a UK residential property since then you can use this calculator to work out how much tax you owe.
+calc.introduction.textOne = If you''ve made or lost money on a UK residential property since then you can use this calculator to work out how much tax you owe.
 calc.introduction.textTwo = You should tell HMRC less than 30 days after you stop owning a property.
 calc.introduction.listOneTitle = Before you start
 calc.introduction.listOneText = Make sure you know:
@@ -40,13 +40,13 @@ calc.introduction.listTwoTitle = Residential properties
 calc.introduction.listTwoText = Residential properties can be:
 calc.introduction.listTwoBulletOne = houses
 calc.introduction.listTwoBulletTwo = apartments
-calc.introduction.listTwoBulletThree = properties that haven't been built yet
+calc.introduction.listTwoBulletThree = properties that haven''t been built yet
 calc.introduction.listThreeTitle = Changing owners
 calc.introduction.listThreeText = You no longer own a property when you either:
 calc.introduction.listThreeBulletOne = sell it
 calc.introduction.listThreeBulletTwo = give it away
 calc.introduction.listThreeBulletThree = swap it
-calc.introduction.listThreeBulletFour = get compensation if it's destroyed
+calc.introduction.listThreeBulletFour = get compensation if it''s destroyed
 calc.introduction.start = Start
 
 ## Customer Type ##
@@ -56,8 +56,8 @@ calc.customerType.trustee = I was a trustee
 calc.customerType.personalRep = I was the executor of an estate
 
 ## Disabled Trustee ##
-calc.disabledTrustee.question = Are you a trustee for someone who’s vulnerable?
-calc.disabledTrustee.helptext = A person’s vulnerable if they’re disabled, or if they’re under 18 and their parents have died
+calc.disabledTrustee.question = Are you a trustee for someone who''s vulnerable?
+calc.disabledTrustee.helptext = A person''s vulnerable if they''re disabled, or if they''re under 18 and their parents have died
 
 ## Current Income ##
 calc.currentIncome.question = In the tax year when you stopped owning the property, what was your total UK income?
@@ -75,7 +75,7 @@ calc.personalAllowance.errorNegative = Your Personal Allowance can''t be negativ
 calc.personalAllowance.errorDecimalPlaces = Your Personal Allowance has too many decimal numbers
 
 ## Other Properties ##
-calc.otherProperties.question = Did you sell or give away any other properties in that tax year?
+calc.otherProperties.question = In the tax year when you stopped owning the property, did you sell or give away anything else that''s covered by Capital Gains Tax?
 
 ## Annual Exempt Amount ##
 calc.annualExemptAmount.question = How much of your Capital Gains Tax allowance have you got left?

--- a/conf/messages
+++ b/conf/messages
@@ -135,6 +135,9 @@ calc.allowableLosses.errorMinimum = The value of your allowable losses cannot be
 ## Other Reliefs ##
 calc.otherReliefs.question = How much extra tax relief are you claiming?
 calc.otherReliefs.errorMinimum = Other reliefs cannot be negative
+calc.otherReliefs.totalGain = Total gain
+calc.otherReliefs.taxableGain = Taxable gain
+calc.otherReliefs.button.addRelief = Add relief
 
 ## Summary ##
 calc.summary.title = Summary

--- a/public/stylesheets/cgt.css
+++ b/public/stylesheets/cgt.css
@@ -1,0 +1,11 @@
+.poundSign {
+    position:relative;
+    margin-left:5px;
+    margin-right:-20px;
+    top:1px;
+    left:2px;
+}
+.moneyField {
+    padding-left:20px;
+    text-align:left;
+}

--- a/test/controllers/CalculationControllerSpec.scala
+++ b/test/controllers/CalculationControllerSpec.scala
@@ -2265,8 +2265,16 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication with M
           OtherReliefsTestDataItem.jsoupDoc.body.getElementById("otherReliefs").tagName() shouldEqual "input"
         }
 
-        "display a 'Continue' button " in {
-          OtherReliefsTestDataItem.jsoupDoc.body.getElementById("continue-button").text shouldEqual Messages("calc.base.continue")
+        "display an 'Add relief' button " in {
+          OtherReliefsTestDataItem.jsoupDoc.body.getElementById("add-relief-button").text shouldEqual Messages("calc.otherReliefs.button.addRelief")
+        }
+
+        "include helptext for 'Total gain'" in {
+          OtherReliefsTestDataItem.jsoupDoc.body.getElementById("totalGain").text should include (Messages("calc.otherReliefs.totalGain"))
+        }
+
+        "include helptext for 'Taxable gain'" in {
+          OtherReliefsTestDataItem.jsoupDoc.body.getElementById("taxableGain").text should include (Messages("calc.otherReliefs.taxableGain"))
         }
       }
     }

--- a/test/controllers/CalculationControllerSpec.scala
+++ b/test/controllers/CalculationControllerSpec.scala
@@ -98,7 +98,7 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication with M
 
         "have a 'Back' link " in {
           keystoreFetchCondition[CustomerTypeModel](None)
-          CustomerTypeTestDataItem.jsoupDoc.body.getElementById("link-back").text shouldEqual Messages("calc.base.back")
+          CustomerTypeTestDataItem.jsoupDoc.body.getElementById("back-link").text shouldEqual Messages("calc.base.back")
         }
 
         "have the question 'Who owned the property?' as the legend of the input" in {
@@ -264,7 +264,7 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication with M
 
         "have a 'Back' link " in {
           keystoreFetchCondition[DisabledTrusteeModel](None)
-          DisabledTrusteeTestDataItem.jsoupDoc.body.getElementById("link-back").text shouldEqual Messages("calc.base.back")
+          DisabledTrusteeTestDataItem.jsoupDoc.body.getElementById("back-link").text shouldEqual Messages("calc.base.back")
         }
 
         "have the question 'When did you sign the contract that made someone else the owner?' as the legend of the input" in {
@@ -386,12 +386,12 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication with M
 
         "have a 'Back' link " in {
           keystoreFetchCondition[PersonalAllowanceModel](None)
-          PersonalAllowanceTestDataItem.jsoupDoc.body.getElementById("link-back").text shouldEqual Messages("calc.base.back")
+          PersonalAllowanceTestDataItem.jsoupDoc.body.getElementById("back-link").text shouldEqual Messages("calc.base.back")
         }
 
         "have the question 'In the tax year when you stopped owning the property, what was your UK Personal Allowance?' as the label of the input" in {
           keystoreFetchCondition[PersonalAllowanceModel](None)
-          PersonalAllowanceTestDataItem.jsoupDoc.body.getElementsByTag("label").text shouldEqual Messages("calc.personalAllowance.question")
+          PersonalAllowanceTestDataItem.jsoupDoc.body.getElementsByTag("label").text should include (Messages("calc.personalAllowance.question"))
         }
 
         "display an input box for the Personal Allowance" in {
@@ -540,7 +540,7 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication with M
         }
 
         "have a 'Back' link " in {
-          OtherPropertiesTestDataItem.jsoupDoc.body.getElementById("link-back").text shouldEqual Messages("calc.base.back")
+          OtherPropertiesTestDataItem.jsoupDoc.body.getElementById("back-link").text shouldEqual Messages("calc.base.back")
         }
 
         "have the question 'Did you sell or give away any other properties in that tax year?' as the legend of the input" in {
@@ -665,12 +665,12 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication with M
 
         "have a 'Back' link " in {
           keystoreFetchCondition[AnnualExemptAmountModel](None)
-          AnnualExemptAmountTestDataItem.jsoupDoc.body.getElementById("link-back").text shouldEqual Messages("calc.base.back")
+          AnnualExemptAmountTestDataItem.jsoupDoc.body.getElementById("back-link").text shouldEqual Messages("calc.base.back")
         }
 
         "have the question 'How much of your Capital Gains Tax allowance have you got left?' as the legend of the input" in {
           keystoreFetchCondition[AnnualExemptAmountModel](None)
-          AnnualExemptAmountTestDataItem.jsoupDoc.body.getElementsByTag("label").text shouldEqual Messages("calc.annualExemptAmount.question")
+          AnnualExemptAmountTestDataItem.jsoupDoc.body.getElementsByTag("label").text should include (Messages("calc.annualExemptAmount.question"))
         }
 
         "display an input box for the Annual Exempt Amount" in {
@@ -833,12 +833,12 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication with M
 
         "have a 'Back' link " in {
           keystoreFetchCondition[AcquisitionValueModel](None)
-          AcquisitionValueTestDataItem.jsoupDoc.body.getElementById("link-back").text shouldEqual Messages("calc.base.back")
+          AcquisitionValueTestDataItem.jsoupDoc.body.getElementById("back-link").text shouldEqual Messages("calc.base.back")
         }
 
         "have the question 'How much did you pay for the property?'" in {
           keystoreFetchCondition[AcquisitionValueModel](None)
-          AcquisitionValueTestDataItem.jsoupDoc.body.getElementsByTag("label").text shouldEqual Messages("calc.acquisitionValue.question")
+          AcquisitionValueTestDataItem.jsoupDoc.body.getElementsByTag("label").text should include (Messages("calc.acquisitionValue.question"))
         }
 
         "display an input box for the Acquisition Value" in {
@@ -984,7 +984,7 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication with M
         }
 
         "contain a hidden component with an input box" in {
-          ImprovementsTestDataItem.jsoupDoc.body.getElementById("improvementsAmt").parent.parent.id shouldBe "hidden"
+          ImprovementsTestDataItem.jsoupDoc.body.getElementById("hidden").html should include ("input")
         }
       }
     }
@@ -1151,11 +1151,11 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication with M
         }
 
         "have a 'Back' link " in {
-          DisposalDateTestDataItem.jsoupDoc.body.getElementById("link-back").text shouldEqual Messages("calc.base.back")
+          DisposalDateTestDataItem.jsoupDoc.body.getElementById("back-link").text shouldEqual Messages("calc.base.back")
         }
 
-        "have the question 'Who owned the property?' as the legend of the input" in {
-          DisposalDateTestDataItem.jsoupDoc.body.getElementsByTag("legend").text shouldEqual Messages("calc.disposalDate.question")
+        s"have the question '${Messages("calc.disposalDate.question")}'" in {
+          DisposalDateTestDataItem.jsoupDoc.body.getElementsByTag("fieldset").text should include (Messages("calc.disposalDate.question"))
         }
 
         "display three input boxes with labels Day, Month and Year respectively" in {
@@ -1413,12 +1413,12 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication with M
 
         "have a 'Back' link " in {
           keystoreFetchCondition[DisposalValueModel](None)
-          DisposalValueTestDataItem.jsoupDoc.body.getElementById("link-back").text shouldEqual Messages("calc.base.back")
+          DisposalValueTestDataItem.jsoupDoc.body.getElementById("back-link").text shouldEqual Messages("calc.base.back")
         }
 
         "have the question 'How much did you sell or give away the property for?' as the legend of the input" in {
           keystoreFetchCondition[DisposalValueModel](None)
-          DisposalValueTestDataItem.jsoupDoc.body.getElementsByTag("label").text shouldEqual Messages("calc.disposalValue.question")
+          DisposalValueTestDataItem.jsoupDoc.body.getElementsByTag("label").text should include (Messages("calc.disposalValue.question"))
         }
 
         "display an input box for the Annual Exempt Amount" in {
@@ -1550,7 +1550,7 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication with M
 
         "have a back link" in {
           keystoreFetchCondition[AcquisitionCostsModel](None)
-          AcquisitionCostsTestDataItem.jsoupDoc.getElementById("link-back").text shouldEqual Messages("calc.base.back")
+          AcquisitionCostsTestDataItem.jsoupDoc.getElementById("back-link").text shouldEqual Messages("calc.base.back")
         }
 
         "have the page heading 'Calculate your tax (non-residents)'" in {
@@ -1562,7 +1562,7 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication with M
 
           "have the title 'How much did you pay in costs when you became the property owner?'" in {
             keystoreFetchCondition[AcquisitionCostsModel](None)
-            AcquisitionCostsTestDataItem.jsoupDoc.select("label[for=acquisitionCosts]").text.contains(Messages("calc.acquisitionCosts.question")) shouldBe true
+            AcquisitionCostsTestDataItem.jsoupDoc.select("label[for=acquisitionCosts]").text should include (Messages("calc.acquisitionCosts.question"))
           }
 
           "have the help text 'Costs include agent fees, legal fees and surveys'" in {
@@ -1722,7 +1722,7 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication with M
         }
 
         "have a back link" in {
-          DisposalCostsTestDataItem.jsoupDoc.getElementById("link-back").text shouldEqual Messages("calc.base.back")
+          DisposalCostsTestDataItem.jsoupDoc.getElementById("back-link").text shouldEqual Messages("calc.base.back")
         }
 
         "have the heading 'Calculate your tax (non-residents)'" in {
@@ -1732,7 +1732,7 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication with M
         "have a monetary field that" should {
 
           "have the title 'How much did you pay in costs when you became the property owner?'" in {
-            DisposalCostsTestDataItem.jsoupDoc.select("label[for=disposalCosts]").text shouldEqual Messages("calc.disposalCosts.question")
+            DisposalCostsTestDataItem.jsoupDoc.select("label[for=disposalCosts]").text should include (Messages("calc.disposalCosts.question"))
           }
 
           "have an input box for the disposal costs" in {
@@ -1754,7 +1754,7 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication with M
     }
     "supplied with a pre-existing stored model" should {
       object DisposalCostsTestDataItem extends fakeRequestTo("disposal-costs", TestCalculationController.disposalCosts)
-      val disposalCostsTestModel = new DisposalCostsModel(1000)
+      val disposalCostsTestModel = new DisposalCostsModel(Some(1000))
 
       "return a 200" in {
         keystoreFetchCondition[DisposalCostsModel](Some(disposalCostsTestModel))
@@ -1784,7 +1784,7 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication with M
       }
 
       "submitting a valid form" should {
-        val disposalCostsTestModel = new DisposalCostsModel(1000)
+        val disposalCostsTestModel = new DisposalCostsModel(Some(1000))
         object DisposalCostsTestDataItem extends fakeRequestToPost(
           "disposal-costs",
           TestCalculationController.submitDisposalCosts,
@@ -1802,21 +1802,21 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication with M
         }
       }
 
-      "submitting an invalid form with no value" should {
-        val disposalCostsTestModel = new DisposalCostsModel(0)
+      "submitting an valid form with no value" should {
+        val disposalCostsTestModel = new DisposalCostsModel(Some(0))
         object DisposalCostsTestDataItem extends fakeRequestToPost(
           "disposal-costs",
           TestCalculationController.submitDisposalCosts,
           ("disposalCosts", "")
         )
 
-        "return a 400" in {
+        "return a 303" in {
           keystoreCacheCondition(disposalCostsTestModel)
-          status(DisposalCostsTestDataItem.result) shouldBe 400
+          status(DisposalCostsTestDataItem.result) shouldBe 303
         }
       }
       "submitting an invalid form with a negative value of -432" should {
-        val disposalCostsTestModel = new DisposalCostsModel(0)
+        val disposalCostsTestModel = new DisposalCostsModel(Some(0))
         object DisposalCostsTestDataItem extends fakeRequestToPost(
           "disposal-costs",
           TestCalculationController.submitDisposalCosts,
@@ -1835,7 +1835,7 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication with M
       }
 
       "submitting an invalid form with a value that has more than two decimal places" should {
-        val disposalCostsTestModel = new DisposalCostsModel(0)
+        val disposalCostsTestModel = new DisposalCostsModel(Some(0))
         object DisposalCostsTestDataItem extends fakeRequestToPost(
           "disposal-costs",
           TestCalculationController.submitDisposalCosts,
@@ -1854,7 +1854,7 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication with M
       }
 
       "submitting an invalid form with a value that is negative and has more than two decimal places" should {
-        val disposalCostsTestModel = new DisposalCostsModel(0)
+        val disposalCostsTestModel = new DisposalCostsModel(Some(0))
         object DisposalCostsTestDataItem extends fakeRequestToPost(
           "disposal-costs",
           TestCalculationController.submitDisposalCosts,
@@ -1905,7 +1905,7 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication with M
 
         "have a 'Back' link " in {
           keystoreFetchCondition[EntrepreneursReliefModel](None)
-          EntrepreneursReliefTestDataItem.jsoupDoc.body.getElementById("link-back").text shouldEqual Messages("calc.base.back")
+          EntrepreneursReliefTestDataItem.jsoupDoc.body.getElementById("back-link").text shouldEqual Messages("calc.base.back")
         }
 
         "have the question 'Are you claiming Entrepreneurs Relief?' as the legend of the input" in {
@@ -2032,7 +2032,7 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication with M
 
         "have a back button" in {
           keystoreFetchCondition[AllowableLossesModel](None)
-          AllowableLossesTestDataItem.jsoupDoc.body.getElementById("link-back").text shouldEqual Messages("calc.base.back")
+          AllowableLossesTestDataItem.jsoupDoc.body.getElementById("back-link").text shouldEqual Messages("calc.base.back")
         }
 
         "have the title 'Are you claiming any allowable losses?'" in {
@@ -2055,7 +2055,7 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication with M
         "have a hidden monetary input with question 'Whats the total value of your allowable losses?'" in {
           keystoreFetchCondition[AllowableLossesModel](None)
           AllowableLossesTestDataItem.jsoupDoc.body.getElementById("allowableLossesAmt").tagName shouldEqual "input"
-          AllowableLossesTestDataItem.jsoupDoc.select("label[for=allowableLossesAmt]").text shouldEqual Messages("calc.allowableLosses.question.two")
+          AllowableLossesTestDataItem.jsoupDoc.select("label[for=allowableLossesAmt]").text should include (Messages("calc.allowableLosses.question.two"))
         }
 
         "have no value auto-filled into the input box" in {
@@ -2254,11 +2254,11 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication with M
         }
 
         "have a 'Back' link " in {
-          OtherReliefsTestDataItem.jsoupDoc.body.getElementById("link-back").text shouldEqual Messages("calc.base.back")
+          OtherReliefsTestDataItem.jsoupDoc.body.getElementById("back-link").text shouldEqual Messages("calc.base.back")
         }
 
         "have the question 'How much extra tax relief are you claiming?' as the legend of the input" in {
-          OtherReliefsTestDataItem.jsoupDoc.body.getElementsByTag("label").text shouldEqual Messages("calc.otherReliefs.question")
+          OtherReliefsTestDataItem.jsoupDoc.body.getElementsByTag("label").text should include (Messages("calc.otherReliefs.question"))
         }
 
         "display an input box for the Other Tax Reliefs" in {
@@ -2543,7 +2543,7 @@ class CalculationControllerSpec extends UnitSpec with WithFakeApplication with M
 
         "have a 'Back' link " in {
           keystoreFetchCondition[CurrentIncomeModel](None)
-          CurrentIncomeTestDataItem.jsoupDoc.body.getElementById("link-back").text shouldEqual Messages("calc.base.back")
+          CurrentIncomeTestDataItem.jsoupDoc.body.getElementById("back-link").text shouldEqual Messages("calc.base.back")
         }
 
         "have the question 'In the tax year when you stopped owning the property, what was your total UK income?' as the label of the input" in {


### PR DESCRIPTION
**Note**

There are a large number of changes included in this.

The main changes are:

- Read more sidebar has blue heading. Ensured that the links are a list of items.
- A pound sign has been overlayed on top of the input field for monetary values - this required a new helper (although there may be better ways to do this that avoid needing a new helper)
- Monetary inputs have been set to type number with a step of 0.01.
- "link-back" class changed to "back-link"
- corrected the rendering of the error messages to ensure that they are consistent across all pages.
- Disposal Cost validation has been amended to be optional.
- Improvements form validation has been amended to align with the allowable losses.
- scalatests have been updated for everything