### PR TITLE
CGT-864: Added page form bindings and keystore for post action.

### DIFF
--- a/app/common/Dates.scala
+++ b/app/common/Dates.scala
@@ -17,7 +17,7 @@
 package common
 
 import java.text.SimpleDateFormat
-import java.util.Date
+import java.util.{Calendar, Date}
 
 object Dates {
 
@@ -40,6 +40,17 @@ object Dates {
 
   def dateAfterOctober (date: Date): Boolean = {
     date.after(taxStartDatePlus18Months)
+  }
+
+  def dateMinusMonths(date: Option[Date], months: Int): String = {
+    date match {
+      case Some(date) =>
+        val cal = Calendar.getInstance()
+        cal.setTime(date)
+        cal.add(Calendar.MONTH, months * -1)
+        new SimpleDateFormat("d MMMMM yyyy").format(cal.getTime)
+      case _ => ""
+    }
   }
 }
 

--- a/app/controllers/CalculationController.scala
+++ b/app/controllers/CalculationController.scala
@@ -405,65 +405,62 @@ trait CalculationController extends FrontendController {
   }
 
   //################### Private Residence Relief methods #######################
-  val privateResidenceRelief = Action.async { implicit request =>
-
-    def getDisposalDate: Future[Option[Date]] = calcConnector.fetchAndGetFormData[DisposalDateModel](KeystoreKeys.disposalDate).map {
+  def getDisposalDate(implicit hc: HeaderCarrier): Future[Option[Date]] =
+    calcConnector.fetchAndGetFormData[DisposalDateModel](KeystoreKeys.disposalDate).map {
       case Some(data) => Some(Dates.constructDate(data.day, data.month, data.year))
       case _ => None
-    }
+  }
 
-    def getAcquisitionDate: Future[Option[Date]] = calcConnector.fetchAndGetFormData[AcquisitionDateModel](KeystoreKeys.acquisitionDate).map {
+  def getAcquisitionDate(implicit hc: HeaderCarrier): Future[Option[Date]] =
+    calcConnector.fetchAndGetFormData[AcquisitionDateModel](KeystoreKeys.acquisitionDate).map {
       case Some(data) => data.hasAcquisitionDate match {
         case "Yes" => Some(Dates.constructDate(data.day.get, data.month.get, data.year.get))
         case _ => None
-      }
-      case _ => None
     }
+    case _ => None
+  }
 
-    def getRebasedAmount: Future[Boolean] = calcConnector.fetchAndGetFormData[RebasedValueModel](KeystoreKeys.rebasedValue).map {
+  def getRebasedAmount(implicit hc: HeaderCarrier): Future[Boolean] =
+    calcConnector.fetchAndGetFormData[RebasedValueModel](KeystoreKeys.rebasedValue).map {
       case Some(data) if data.hasRebasedValue == "Yes" => true
       case _ => false
-    }
+  }
+
+  def displayBetweenQuestion(disposalDate: Option[Date], acquisitionDate: Option[Date], hasRebasedValue: Boolean): Boolean =
+    disposalDate match {
+      case Some(date) =>
+        if (Dates.dateAfterOctober(date)) {
+          acquisitionDate match {
+            case Some(acquisitionDateValue) if !Dates.dateAfterStart(acquisitionDateValue) => true
+            case _ => if (hasRebasedValue) true else false
+          }
+        } else false
+      case _ => false
+  }
+
+  def displayBeforeQuestion(disposalDate: Option[Date], acquisitionDate: Option[Date], hasRebasedValue: Boolean): Boolean = disposalDate match {
+    case Some(disposalDateValue) =>
+      if (Dates.dateAfterOctober(disposalDateValue)) {
+        acquisitionDate match {
+          case Some(acquisitionDateValue) => true
+          case _ => false
+        }
+      } else {
+        acquisitionDate match {
+          case Some(acquisitionDateValue) if !Dates.dateAfterStart(acquisitionDateValue) => true
+          case _ => false
+        }
+      }
+    case _ => false
+  }
+
+  val privateResidenceRelief = Action.async { implicit request =>
 
     def action(disposalDate: Option[Date], acquisitionDate: Option[Date], hasRebasedValue: Boolean) = {
 
-      //Determine whether to show the Between question
-      val showBetweenQuestion = disposalDate match {
-        case Some(date) =>
-          if (Dates.dateAfterOctober(date)) {
-            acquisitionDate match {
-              case Some(acquisitionDateValue) if !Dates.dateAfterStart(acquisitionDateValue) => true
-              case _ => if (hasRebasedValue) true else false
-            }
-          } else false
-        case _ => false
-      }
-
-      //Determine whether to show the Before question
-      val showBeforeQuestion = disposalDate match {
-        case Some(disposalDateValue) =>
-          if (Dates.dateAfterOctober(disposalDateValue)) {
-            acquisitionDate match {
-              case Some(acquisitionDateValue) => true
-              case _ => false
-            }
-          } else {
-            acquisitionDate match {
-              case Some(acquisitionDateValue) if !Dates.dateAfterStart(acquisitionDateValue) => true
-              case _ => false
-            }
-          }
-        case _ => false
-      }
-
-      val disposalDateLess18Months = disposalDate match {
-        case Some(date) =>
-          val cal = Calendar.getInstance()
-          cal.setTime(disposalDate.get)
-          cal.add(Calendar.MONTH,-18)
-          new SimpleDateFormat("d MMMMM yyyy").format(cal.getTime)
-        case _ => ""
-      }
+      val showBetweenQuestion = displayBetweenQuestion(disposalDate, acquisitionDate, hasRebasedValue)
+      val showBeforeQuestion = displayBeforeQuestion(disposalDate, acquisitionDate, hasRebasedValue)
+      val disposalDateLess18Months = Dates.dateMinusMonths(disposalDate,18)
 
       calcConnector.fetchAndGetFormData[PrivateResidenceReliefModel](KeystoreKeys.privateResidenceRelief).map {
         case Some(data) => Ok(calculation.privateResidenceRelief(privateResidenceReliefForm.fill(data), showBetweenQuestion, showBeforeQuestion, disposalDateLess18Months))
@@ -481,7 +478,29 @@ trait CalculationController extends FrontendController {
   }
 
   val submitPrivateResidenceRelief = Action.async { implicit request =>
-    Future.successful(Redirect(routes.CalculationController.entrepreneursRelief()))
+
+    def action(disposalDate: Option[Date], acquisitionDate: Option[Date], hasRebasedValue: Boolean) = {
+
+      privateResidenceReliefForm.bindFromRequest.fold(
+        errors => {
+          val showBetweenQuestion = displayBetweenQuestion(disposalDate, acquisitionDate, hasRebasedValue)
+          val showBeforeQuestion = displayBeforeQuestion(disposalDate, acquisitionDate, hasRebasedValue)
+          val disposalDateLess18Months = Dates.dateMinusMonths(disposalDate,18)
+          Future.successful(BadRequest(calculation.privateResidenceRelief(errors,showBetweenQuestion, showBeforeQuestion, disposalDateLess18Months)))
+        },
+        success => {
+          calcConnector.saveFormData(KeystoreKeys.privateResidenceRelief, success)
+          Future.successful(Redirect(routes.CalculationController.entrepreneursRelief()))
+        }
+      )
+    }
+
+    for {
+      disposalDate <- getDisposalDate
+      acquisitionDate <- getAcquisitionDate
+      hasRebasedValue <- getRebasedAmount
+      finalResult <- action(disposalDate, acquisitionDate, hasRebasedValue)
+    } yield finalResult
   }
 
   //################### Entrepreneurs Relief methods #######################

--- a/test/controllers/CalculationControllerTests/PrivateResidenceReliefSpec.scala
+++ b/test/controllers/CalculationControllerTests/PrivateResidenceReliefSpec.scala
@@ -640,27 +640,40 @@ class PrivateResidenceReliefSpec extends UnitSpec with WithFakeApplication with 
         ("daysClaimed", daysClaimed),
         ("daysClaimedAfter",daysClaimedAfter)
       )
-      val daysClaimedValue = daysClaimed match {
-        case "" => 0
-        case _ => BigDecimal(daysClaimed)
+      val numeric = "(0-9*)".r
+      val daysClaimedValue: BigDecimal = daysClaimed match {
+        case numeric(data) => BigDecimal(data)
+        case _ => 0
       }
-      val daysClaimedAfterValue = daysClaimedAfter match {
-        case "" => 0
-        case _ => BigDecimal(daysClaimed)
+      val daysClaimedAfterValue: BigDecimal = daysClaimedAfter match {
+        case numeric(data) => BigDecimal(data)
+        case _ => 0
       }
-      val mockData = Some(PrivateResidenceReliefModel(selection, Some(BigDecimal(daysClaimed)), Some(BigDecimal(daysClaimedAfter))))
+      val mockData = Some(PrivateResidenceReliefModel(selection, Some(daysClaimedValue), Some(daysClaimedAfterValue)))
       val target = setupTarget(None, mockData, disposalDateData, acquisitionDateData, rebasedValueData)
-      target.submitPersonalAllowance(fakeRequest)
+      target.submitPrivateResidenceRelief(fakeRequest)
     }
 
-    lazy val result = executeTargetWithMockData("Yes", "", "")
+    "when supplied with a valid model" should {
 
-    "return a 303" in {
-      status(result) shouldBe 303
+      lazy val result = executeTargetWithMockData("Yes", "", "")
+
+      "return a 303" in {
+        status(result) shouldBe 303
+      }
+
+      s"redirect to ${routes.CalculationController.entrepreneursRelief()}" in {
+        redirectLocation(result) shouldBe Some(s"${routes.CalculationController.entrepreneursRelief()}")
+      }
     }
 
-    s"redirect to ${routes.CalculationController.entrepreneursRelief()}" in {
-      redirectLocation(result) shouldBe Some(s"${routes.CalculationController.entrepreneursRelief()}")
+    "when supplied with an invalid model" should {
+
+      lazy val result = executeTargetWithMockData("", "", "")
+
+      "return a 400" in {
+        status(result) shouldBe 400
+      }
     }
   }
 }


### PR DESCRIPTION
The logic for the POST route was extremely similar as for the GET, to determine which fields should be displayed on the PRR screen (required when the form has errors)

Therefore, this code was refactored out of the `privateResidenceRelief()` action and written as shared functions to be used by both `privateResidenceRelief()` and `submitPrivateResidenceRelief()`