### PR TITLE
CGT-1041: Added dynamic back links based on user journey.

### DIFF
--- a/app/common/DefaultRoutes.scala
+++ b/app/common/DefaultRoutes.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import controllers.routes
+
+object DefaultRoutes extends DefaultRoutes
+
+trait DefaultRoutes {
+
+  val missingDataRoute = routes.IntroductionController.introduction().url
+
+}

--- a/app/controllers/CalculationController.scala
+++ b/app/controllers/CalculationController.scala
@@ -234,10 +234,13 @@ trait CalculationController extends FrontendController {
   //################### Acquisition Date methods #######################
   def acquisitionDateBackUrl(implicit hc: HeaderCarrier): Future[String] = {
     calcConnector.fetchAndGetFormData[OtherPropertiesModel](KeystoreKeys.otherProperties).map {
-      case Some(data) => data.otherPropertiesAmt match {
-        case Some(value) if value > 0 => routes.CalculationController.annualExemptAmount().url
-        case _ => routes.CalculationController.otherProperties().url
-      }
+      case Some(data) if data.otherProperties == "Yes" =>
+        if (data.otherPropertiesAmt.get == 0) {
+          routes.CalculationController.annualExemptAmount().url
+        } else {
+          routes.CalculationController.otherProperties().url
+        }
+      case Some(data) if data.otherProperties == "No" => routes.CalculationController.otherProperties().url
       case _ => missingDataRoute
     }
   }

--- a/app/views/calculation/acquisitionDate.scala.html
+++ b/app/views/calculation/acquisitionDate.scala.html
@@ -3,11 +3,11 @@
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 @import views.html.helpers._
 
-@(acquisitionDateForm: Form[AcquisitionDateModel])(implicit request: Request[_])
+@(acquisitionDateForm: Form[AcquisitionDateModel], backUrl: String)(implicit request: Request[_])
 
 @main_template(Messages("calc.acquisitionDate.question")) {
 
-    <a id="back-link" class="back-link" href="#">@Messages("calc.base.back")</a>
+    <a id="back-link" class="back-link" href="@backUrl">@Messages("calc.base.back")</a>
 
     @govHelpers.errorSummary(Messages("calc.error.summary.heading"), acquisitionDateForm)
 

--- a/app/views/calculation/entrepreneursRelief.scala.html
+++ b/app/views/calculation/entrepreneursRelief.scala.html
@@ -1,4 +1,4 @@
-@(entrepreneursReliefForm: Form[EntrepreneursReliefModel])(implicit request: Request[_])
+@(entrepreneursReliefForm: Form[EntrepreneursReliefModel], backUrl: String)(implicit request: Request[_])
 
 @import models.OtherPropertiesModel
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
@@ -10,7 +10,7 @@
 
 @main_template(Messages("calc.entrepreneursRelief.question"), sidebarLinks = Some(sidebar)) {
 
-    <a id="back-link" class="back-link" href="#">@Messages("calc.base.back")</a>
+    <a id="back-link" class="back-link" href="@backUrl">@Messages("calc.base.back")</a>
 
     @govHelpers.errorSummary(Messages("calc.error.summary.heading"), entrepreneursReliefForm)
 

--- a/app/views/calculation/improvements.scala.html
+++ b/app/views/calculation/improvements.scala.html
@@ -3,11 +3,11 @@
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 @import views.html.helpers._
 
-@(improvementsForm: Form[ImprovementsModel], hasRebasedValue: String)(implicit request: Request[_])
+@(improvementsForm: Form[ImprovementsModel], hasRebasedValue: String, backUrl: String)(implicit request: Request[_])
 
 @main_template(Messages("calc.improvements.question")) {
 
-    <a id="back-link" class="back-link" href="#">@Messages("calc.base.back")</a>
+    <a id="back-link" class="back-link" href="@backUrl">@Messages("calc.base.back")</a>
 
     @govHelpers.errorSummary(Messages("calc.error.summary.heading"), improvementsForm)
 

--- a/app/views/calculation/otherProperties.scala.html
+++ b/app/views/calculation/otherProperties.scala.html
@@ -2,7 +2,7 @@
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 @import views.html.helpers._
 
-@(otherPropertiesForm: Form[OtherPropertiesModel])(implicit request: Request[_])
+@(otherPropertiesForm: Form[OtherPropertiesModel], backUrl: String)(implicit request: Request[_])
 
 @hiddenYesNoContent = {
     @formInputMoney(otherPropertiesForm, "otherPropertiesAmt", Messages("calc.otherProperties.questionTwo"))
@@ -10,7 +10,7 @@
 
 @main_template(Messages("calc.otherProperties.question")) {
 
-    <a id="back-link" class="back-link" href="">@Messages("calc.base.back")</a>
+    <a id="back-link" class="back-link" href="@backUrl">@Messages("calc.base.back")</a>
 
     @govHelpers.errorSummary(Messages("calc.error.summary.heading"), otherPropertiesForm)
 

--- a/app/views/calculation/otherReliefs.scala.html
+++ b/app/views/calculation/otherReliefs.scala.html
@@ -3,11 +3,11 @@
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 @import views.html.helpers._
 
-@(otherReliefsForm: Form[OtherReliefsModel], result: CalculationResultModel)(implicit request: Request[_])
+@(otherReliefsForm: Form[OtherReliefsModel], result: CalculationResultModel, backUrl: String)(implicit request: Request[_])
 
 @main_template(Messages("calc.otherReliefs.question")) {
 
-    <a id="back-link" class="back-link" href="#">@Messages("calc.base.back")</a>
+    <a id="back-link" class="back-link" href="@backUrl">@Messages("calc.base.back")</a>
 
     @govHelpers.errorSummary(Messages("calc.error.summary.heading"), otherReliefsForm)
 

--- a/app/views/calculation/summary.scala.html
+++ b/app/views/calculation/summary.scala.html
@@ -1,4 +1,4 @@
-@(summary: SummaryModel, result: CalculationResultModel)(implicit request: Request[_])
+@(summary: SummaryModel, result: CalculationResultModel, backUrl: String)(implicit request: Request[_])
 
 @import views.html.helpers._
 @import org.apache.commons.lang3.text.WordUtils
@@ -9,7 +9,7 @@
 
 @main_template(Messages("calc.summary.title"), articleLayout = false) {
 
-    <a id="back-link" class="back-link" href="#">@Messages("calc.base.back")</a>
+    <a id="back-link" class="back-link" href="@backUrl">@Messages("calc.base.back")</a>
 
     @*
     *  Calculated Tax Owed

--- a/test/controllers/CalculationControllerTests/AcquisitionDateSpec.scala
+++ b/test/controllers/CalculationControllerTests/AcquisitionDateSpec.scala
@@ -16,6 +16,8 @@
 
 package controllers.CalculationControllerTests
 
+import common.KeystoreKeys
+import common.DefaultRoutes._
 import constructors.CalculationElectionConstructor
 import play.api.libs.json.Json
 import uk.gov.hmrc.http.cache.client.CacheMap
@@ -39,13 +41,19 @@ class AcquisitionDateSpec extends UnitSpec with WithFakeApplication with Mockito
 
   implicit val hc = new HeaderCarrier()
 
-  def setupTarget(getData: Option[AcquisitionDateModel], postData: Option[AcquisitionDateModel]): CalculationController = {
+  def setupTarget(getData: Option[AcquisitionDateModel],
+                  postData: Option[AcquisitionDateModel],
+                  otherPropertiesData: Option[OtherPropertiesModel]
+                 ): CalculationController = {
 
     val mockCalcConnector = mock[CalculatorConnector]
     val mockCalcElectionConstructor = mock[CalculationElectionConstructor]
 
     when(mockCalcConnector.fetchAndGetFormData[AcquisitionDateModel](Matchers.anyString())(Matchers.any(), Matchers.any()))
     .thenReturn(Future.successful(getData))
+
+    when(mockCalcConnector.fetchAndGetFormData[OtherPropertiesModel](Matchers.eq(KeystoreKeys.otherProperties))(Matchers.any(), Matchers.any()))
+      .thenReturn(Future.successful(otherPropertiesData))
 
     lazy val data = CacheMap("form-id", Map("data" -> Json.toJson(postData.getOrElse(AcquisitionDateModel("",None,None,None)))))
     when(mockCalcConnector.saveFormData[AcquisitionDateModel](Matchers.anyString(), Matchers.any())(Matchers.any(), Matchers.any()))
@@ -63,57 +71,97 @@ class AcquisitionDateSpec extends UnitSpec with WithFakeApplication with Mockito
     
     "not supplied with a pre-existing model" should {
 
-      val target = setupTarget(None, None)
-      lazy val result = target.acquisitionDate(fakeRequest)
-      lazy val document = Jsoup.parse(bodyOf(result))
-      
-      "return a 200" in {
-        status(result) shouldBe 200
+      "when Previous Taxable Gains is 'No'" should {
+
+        val target = setupTarget(None, None, Some(OtherPropertiesModel("No", None)))
+        lazy val result = target.acquisitionDate(fakeRequest)
+        lazy val document = Jsoup.parse(bodyOf(result))
+
+        "return a 200" in {
+          status(result) shouldBe 200
+        }
+
+        "return some HTML that" should {
+
+          "contain some text and use the character set utf-8" in {
+            contentType(result) shouldBe Some("text/html")
+            charset(result) shouldBe Some("utf-8")
+          }
+
+          s"have the title '${Messages("calc.acquisitionDate.question")}'" in {
+            document.title shouldEqual Messages("calc.acquisitionDate.question")
+          }
+
+          "have the heading Calculate your tax (non-residents) " in {
+            document.body.getElementsByTag("h1").text shouldEqual Messages("calc.base.pageHeading")
+          }
+
+          s"have a 'Back' link to ${routes.CalculationController.otherProperties().url} " in {
+            document.body.getElementById("back-link").text shouldEqual Messages("calc.base.back")
+            document.body.getElementById("back-link").attr("href") shouldEqual routes.CalculationController.otherProperties().url
+          }
+
+          s"have the question '${Messages("calc.acquisitionDate.question")}" in {
+            document.body.getElementsByTag("legend").text should include(Messages("calc.acquisitionDate.question"))
+          }
+
+          "display the correct wording for radio option `yes`" in {
+            document.body.getElementById("hasAcquisitionDate-yes").parent.text shouldEqual Messages("calc.base.yes")
+          }
+
+          "display the correct wording for radio option `no`" in {
+            document.body.getElementById("hasAcquisitionDate-no").parent.text shouldEqual Messages("calc.base.no")
+          }
+
+          "contain a hidden component with an input box" in {
+            document.body.getElementById("hidden").html should include("input")
+          }
+
+          "display three input boxes with labels Day, Month and Year respectively" in {
+            document.select("label[for=acquisitionDate.day]").text shouldEqual Messages("calc.common.date.fields.day")
+            document.select("label[for=acquisitionDate.month]").text shouldEqual Messages("calc.common.date.fields.month")
+            document.select("label[for=acquisitionDate.year]").text shouldEqual Messages("calc.common.date.fields.year")
+          }
+
+          "display a 'Continue' button " in {
+            document.body.getElementById("continue-button").text shouldEqual Messages("calc.base.continue")
+          }
+        }
       }
 
-      "return some HTML that" should {
+      "when Previous Taxable Gains is 'Yes' and amount is 0.00" should {
 
-        "contain some text and use the character set utf-8" in {
-          contentType(result) shouldBe Some("text/html")
-          charset(result) shouldBe Some("utf-8")
-        }
+        val target = setupTarget(None, None, Some(OtherPropertiesModel("Yes", Some(0))))
+        lazy val result = target.acquisitionDate(fakeRequest)
+        lazy val document = Jsoup.parse(bodyOf(result))
 
-        s"have the title '${Messages("calc.acquisitionDate.question")}'" in {
-          document.title shouldEqual Messages("calc.acquisitionDate.question")
-        }
-
-        "have the heading Calculate your tax (non-residents) " in {
-          document.body.getElementsByTag("h1").text shouldEqual Messages("calc.base.pageHeading")
-        }
-
-        "have a 'Back' link " in {
+        s"have a 'Back' link to ${routes.CalculationController.otherProperties().url} " in {
           document.body.getElementById("back-link").text shouldEqual Messages("calc.base.back")
+          document.body.getElementById("back-link").attr("href") shouldEqual routes.CalculationController.otherProperties().url
         }
+      }
 
-        s"have the question '${Messages("calc.acquisitionDate.question")}" in {
-          document.body.getElementsByTag("legend").text should include(Messages("calc.acquisitionDate.question"))
+      "when Previous Taxable Gains is 'Yes' and amount is > 0.00" should {
+
+        val target = setupTarget(None, None, Some(OtherPropertiesModel("Yes", Some(0.01))))
+        lazy val result = target.acquisitionDate(fakeRequest)
+        lazy val document = Jsoup.parse(bodyOf(result))
+
+        s"have a 'Back' link to ${routes.CalculationController.annualExemptAmount().url} " in {
+          document.body.getElementById("back-link").text shouldEqual Messages("calc.base.back")
+          document.body.getElementById("back-link").attr("href") shouldEqual routes.CalculationController.annualExemptAmount().url
         }
+      }
 
-        "display the correct wording for radio option `yes`" in {
-          document.body.getElementById("hasAcquisitionDate-yes").parent.text shouldEqual Messages("calc.base.yes")
-        }
+      "when there is no Previous Taxable Gains model" should {
 
-        "display the correct wording for radio option `no`" in {
-          document.body.getElementById("hasAcquisitionDate-no").parent.text shouldEqual Messages("calc.base.no")
-        }
+        val target = setupTarget(None, None, None)
+        lazy val result = target.acquisitionDate(fakeRequest)
+        lazy val document = Jsoup.parse(bodyOf(result))
 
-        "contain a hidden component with an input box" in {
-          document.body.getElementById("hidden").html should include("input")
-        }
-
-        "display three input boxes with labels Day, Month and Year respectively" in {
-          document.select("label[for=acquisitionDate.day]").text shouldEqual Messages("calc.common.date.fields.day")
-          document.select("label[for=acquisitionDate.month]").text shouldEqual Messages("calc.common.date.fields.month")
-          document.select("label[for=acquisitionDate.year]").text shouldEqual Messages("calc.common.date.fields.year")
-        }
-
-        "display a 'Continue' button " in {
-          document.body.getElementById("continue-button").text shouldEqual Messages("calc.base.continue")
+        s"have a 'Back' link to ${missingDataRoute} " in {
+          document.body.getElementById("back-link").text shouldEqual Messages("calc.base.back")
+          document.body.getElementById("back-link").attr("href") shouldEqual missingDataRoute
         }
       }
     }
@@ -121,7 +169,7 @@ class AcquisitionDateSpec extends UnitSpec with WithFakeApplication with Mockito
     "supplied with a model already filled with data" should {
 
       val testAcquisitionDateModel = new AcquisitionDateModel("Yes", Some(10), Some(12), Some(2016))
-      val target = setupTarget(Some(testAcquisitionDateModel), None)
+      val target = setupTarget(Some(testAcquisitionDateModel), None, Some(OtherPropertiesModel("No",None)))
       lazy val result = target.acquisitionDate(fakeRequest)
       lazy val document = Jsoup.parse(bodyOf(result))
 
@@ -163,7 +211,7 @@ class AcquisitionDateSpec extends UnitSpec with WithFakeApplication with Mockito
         ("acquisitionDate.month", month.getOrElse("").toString),
         ("acquisitionDate.year", year.getOrElse("").toString))
       val mockData = new AcquisitionDateModel("Yes",day,month,year)
-      val target = setupTarget(None, Some(mockData))
+      val target = setupTarget(None, Some(mockData), Some(OtherPropertiesModel("No",None)))
       target.submitAcquisitionDate(fakeRequest)
     }
 

--- a/test/controllers/CalculationControllerTests/AcquisitionDateSpec.scala
+++ b/test/controllers/CalculationControllerTests/AcquisitionDateSpec.scala
@@ -135,9 +135,9 @@ class AcquisitionDateSpec extends UnitSpec with WithFakeApplication with Mockito
         lazy val result = target.acquisitionDate(fakeRequest)
         lazy val document = Jsoup.parse(bodyOf(result))
 
-        s"have a 'Back' link to ${routes.CalculationController.otherProperties().url} " in {
+        s"have a 'Back' link to ${routes.CalculationController.annualExemptAmount().url} " in {
           document.body.getElementById("back-link").text shouldEqual Messages("calc.base.back")
-          document.body.getElementById("back-link").attr("href") shouldEqual routes.CalculationController.otherProperties().url
+          document.body.getElementById("back-link").attr("href") shouldEqual routes.CalculationController.annualExemptAmount().url
         }
       }
 
@@ -147,9 +147,9 @@ class AcquisitionDateSpec extends UnitSpec with WithFakeApplication with Mockito
         lazy val result = target.acquisitionDate(fakeRequest)
         lazy val document = Jsoup.parse(bodyOf(result))
 
-        s"have a 'Back' link to ${routes.CalculationController.annualExemptAmount().url} " in {
+        s"have a 'Back' link to ${routes.CalculationController.otherProperties().url} " in {
           document.body.getElementById("back-link").text shouldEqual Messages("calc.base.back")
-          document.body.getElementById("back-link").attr("href") shouldEqual routes.CalculationController.annualExemptAmount().url
+          document.body.getElementById("back-link").attr("href") shouldEqual routes.CalculationController.otherProperties().url
         }
       }
 

--- a/test/controllers/CalculationControllerTests/SummarySpec.scala
+++ b/test/controllers/CalculationControllerTests/SummarySpec.scala
@@ -16,11 +16,12 @@
 
 package controllers.CalculationControllerTests
 
-import common.TestModels
+import common.DefaultRoutes._
+import common.{KeystoreKeys, TestModels}
 import connectors.CalculatorConnector
 import constructors.CalculationElectionConstructor
 import controllers.{routes, CalculationController}
-import models.{CalculationResultModel, SummaryModel}
+import models.{AcquisitionDateModel, RebasedValueModel, CalculationResultModel, SummaryModel}
 import org.jsoup.Jsoup
 import org.mockito.Matchers
 import org.mockito.Mockito._
@@ -37,11 +38,19 @@ class SummarySpec extends UnitSpec with WithFakeApplication with MockitoSugar {
   implicit val hc = new HeaderCarrier()
   def setupTarget(
                    summary: SummaryModel,
-                   result: CalculationResultModel
+                   result: CalculationResultModel,
+                   acquisitionDateData: Option[AcquisitionDateModel],
+                   rebasedValueData: Option[RebasedValueModel]
                  ): CalculationController = {
 
     val mockCalcConnector = mock[CalculatorConnector]
     val mockCalcElectionConstructor = mock[CalculationElectionConstructor]
+
+    when(mockCalcConnector.fetchAndGetFormData[RebasedValueModel](Matchers.eq(KeystoreKeys.rebasedValue))(Matchers.any(), Matchers.any()))
+      .thenReturn(Future.successful(rebasedValueData))
+
+    when(mockCalcConnector.fetchAndGetFormData[AcquisitionDateModel](Matchers.eq(KeystoreKeys.acquisitionDate))(Matchers.any(), Matchers.any()))
+      .thenReturn(Future.successful(acquisitionDateData))
 
     when(mockCalcConnector.createSummary(Matchers.any()))
       .thenReturn(Future.successful(summary))
@@ -64,10 +73,114 @@ class SummarySpec extends UnitSpec with WithFakeApplication with MockitoSugar {
   "In CalculationController calling the .summary action" when {
     lazy val fakeRequest = FakeRequest("GET", "/calculate-your-capital-gains/summary").withSession(SessionKeys.sessionId -> "12345")
 
+    "Testing the back links for all user types" when {
+
+      "Acquisition Date is > 5 April 2015" should {
+        val target = setupTarget(
+          TestModels.summaryIndividualFlatWithAEA,
+          TestModels.calcModelTwoRates,
+          Some(AcquisitionDateModel("Yes", Some(1), Some(1), Some(2017))),
+          None
+        )
+        lazy val result = target.summary()(fakeRequest)
+        lazy val document = Jsoup.parse(bodyOf(result))
+
+        s"have a 'Back' link to ${routes.CalculationController.otherReliefs().url}" in {
+          document.body.getElementById("back-link").text shouldEqual Messages("calc.base.back")
+          document.body.getElementById("back-link").attr("href") shouldEqual routes.CalculationController.otherReliefs().url
+        }
+      }
+
+      "Acquisition Date is not supplied and no rebased value has been supplied" should {
+        val target = setupTarget(
+          TestModels.summaryIndividualFlatWithAEA,
+          TestModels.calcModelTwoRates,
+          Some(AcquisitionDateModel("No", None,None,None)),
+          Some(RebasedValueModel("No", None))
+        )
+        lazy val result = target.summary()(fakeRequest)
+        lazy val document = Jsoup.parse(bodyOf(result))
+
+        s"have a 'Back' link to ${routes.CalculationController.otherReliefs().url}" in {
+          document.body.getElementById("back-link").text shouldEqual Messages("calc.base.back")
+          document.body.getElementById("back-link").attr("href") shouldEqual routes.CalculationController.otherReliefs().url
+        }
+      }
+
+      "Acquisition Date is not supplied and rebased value is supplied" should {
+        val target = setupTarget(
+          TestModels.summaryIndividualFlatWithAEA,
+          TestModels.calcModelTwoRates,
+          Some(AcquisitionDateModel("No", None,None,None)),
+          Some(RebasedValueModel("Yes", Some(500)))
+        )
+        lazy val result = target.summary()(fakeRequest)
+        lazy val document = Jsoup.parse(bodyOf(result))
+
+        s"have a 'Back' link to ${routes.CalculationController.calculationElection().url}" in {
+          document.body.getElementById("back-link").text shouldEqual Messages("calc.base.back")
+          document.body.getElementById("back-link").attr("href") shouldEqual routes.CalculationController.calculationElection().url
+        }
+      }
+
+      "Acquisition Date <= 5 April 2015" should {
+        val target = setupTarget(
+          TestModels.summaryIndividualFlatWithAEA,
+          TestModels.calcModelTwoRates,
+          Some(AcquisitionDateModel("Yes", Some(1),Some(1),Some(2014))),
+          Some(RebasedValueModel("Yes", Some(500)))
+        )
+        lazy val result = target.summary()(fakeRequest)
+        lazy val document = Jsoup.parse(bodyOf(result))
+
+        s"have a 'Back' link to ${routes.CalculationController.calculationElection().url}" in {
+          document.body.getElementById("back-link").text shouldEqual Messages("calc.base.back")
+          document.body.getElementById("back-link").attr("href") shouldEqual routes.CalculationController.calculationElection().url
+        }
+      }
+
+      "Acquisition Date Model is not supplied" should {
+        val target = setupTarget(
+          TestModels.summaryIndividualFlatWithAEA,
+          TestModels.calcModelTwoRates,
+          None,
+          Some(RebasedValueModel("Yes", Some(500)))
+        )
+        lazy val result = target.summary()(fakeRequest)
+        lazy val document = Jsoup.parse(bodyOf(result))
+
+        s"have a 'Back' link to ${missingDataRoute} " in {
+          document.body.getElementById("back-link").text shouldEqual Messages("calc.base.back")
+          document.body.getElementById("back-link").attr("href") shouldEqual missingDataRoute
+        }
+      }
+
+      "Acquisition Date Model is supplied with no date but Rebased Value Model is not" should {
+        val target = setupTarget(
+          TestModels.summaryIndividualFlatWithAEA,
+          TestModels.calcModelTwoRates,
+          Some(AcquisitionDateModel("No", None,None,None)),
+          None
+        )
+        lazy val result = target.summary()(fakeRequest)
+        lazy val document = Jsoup.parse(bodyOf(result))
+
+        s"have a 'Back' link to ${missingDataRoute} " in {
+          document.body.getElementById("back-link").text shouldEqual Messages("calc.base.back")
+          document.body.getElementById("back-link").attr("href") shouldEqual missingDataRoute
+        }
+      }
+    }
+
     "individual is chosen with a flat calculation" when {
 
       "the user has provided a value for the AEA" should {
-        val target = setupTarget(TestModels.summaryIndividualFlatWithAEA, TestModels.calcModelTwoRates)
+        val target = setupTarget(
+          TestModels.summaryIndividualFlatWithAEA,
+          TestModels.calcModelTwoRates,
+          Some(AcquisitionDateModel("Yes", Some(1), Some(1), Some(2017))),
+          None
+        )
         lazy val result = target.summary()(fakeRequest)
         lazy val document = Jsoup.parse(bodyOf(result))
 
@@ -319,7 +432,12 @@ class SummarySpec extends UnitSpec with WithFakeApplication with MockitoSugar {
       }
 
       "the user has provided no value for the AEA" should {
-        val target = setupTarget(TestModels.summaryIndividualFlatWithoutAEA, TestModels.calcModelOneRate)
+        val target = setupTarget(
+          TestModels.summaryIndividualFlatWithoutAEA,
+          TestModels.calcModelOneRate,
+          Some(AcquisitionDateModel("Yes", Some(1), Some(1), Some(2017))),
+          None
+        )
         lazy val result = target.summary()(fakeRequest)
         lazy val document = Jsoup.parse(bodyOf(result))
 
@@ -357,7 +475,12 @@ class SummarySpec extends UnitSpec with WithFakeApplication with MockitoSugar {
       }
 
       "users calculation results in a loss" should {
-        val target = setupTarget(TestModels.summaryIndividualFlatLoss, TestModels.calcModelLoss)
+        val target = setupTarget(
+          TestModels.summaryIndividualFlatLoss,
+          TestModels.calcModelLoss,
+          Some(AcquisitionDateModel("Yes", Some(1), Some(1), Some(2017))),
+          None
+        )
         lazy val result = target.summary()(fakeRequest)
         lazy val document = Jsoup.parse(bodyOf(result))
 
@@ -374,7 +497,12 @@ class SummarySpec extends UnitSpec with WithFakeApplication with MockitoSugar {
     "regular trustee is chosen with a time apportioned calculation" when {
 
       "the user has provided a value for the AEA" should {
-        val target = setupTarget(TestModels.summaryTrusteeTAWithAEA, TestModels.calcModelOneRate)
+        val target = setupTarget(
+          TestModels.summaryTrusteeTAWithAEA,
+          TestModels.calcModelOneRate,
+          Some(AcquisitionDateModel("Yes", Some(1), Some(1), Some(2017))),
+          None
+        )
         lazy val result = target.summary()(fakeRequest)
         lazy val document = Jsoup.parse(bodyOf(result))
 
@@ -408,7 +536,12 @@ class SummarySpec extends UnitSpec with WithFakeApplication with MockitoSugar {
       }
 
       "the user has provided no value for the AEA" should {
-        val target = setupTarget(TestModels.summaryTrusteeTAWithoutAEA, TestModels.calcModelTwoRates)
+        val target = setupTarget(
+          TestModels.summaryTrusteeTAWithoutAEA,
+          TestModels.calcModelTwoRates,
+          Some(AcquisitionDateModel("Yes", Some(1), Some(1), Some(2017))),
+          None
+        )
         lazy val result = target.summary()(fakeRequest)
         lazy val document = Jsoup.parse(bodyOf(result))
 
@@ -425,7 +558,12 @@ class SummarySpec extends UnitSpec with WithFakeApplication with MockitoSugar {
     "disabled trustee is chosen with a time apportioned calculation" when {
 
       "the user has provided a value for the AEA" should {
-        val target = setupTarget(TestModels.summaryDisabledTrusteeTAWithAEA, TestModels.calcModelTwoRates)
+        val target = setupTarget(
+          TestModels.summaryDisabledTrusteeTAWithAEA,
+          TestModels.calcModelTwoRates,
+          Some(AcquisitionDateModel("Yes", Some(1), Some(1), Some(2017))),
+          None
+        )
         lazy val result = target.summary()(fakeRequest)
         lazy val document = Jsoup.parse(bodyOf(result))
 
@@ -439,7 +577,12 @@ class SummarySpec extends UnitSpec with WithFakeApplication with MockitoSugar {
       }
 
       "the user has provided no value for the AEA" should {
-        val target = setupTarget(TestModels.summaryDisabledTrusteeTAWithoutAEA, TestModels.calcModelTwoRates)
+        val target = setupTarget(
+          TestModels.summaryDisabledTrusteeTAWithoutAEA,
+          TestModels.calcModelTwoRates,
+          Some(AcquisitionDateModel("Yes", Some(1), Some(1), Some(2017))),
+          None
+        )
         lazy val result = target.summary()(fakeRequest)
         lazy val document = Jsoup.parse(bodyOf(result))
 
@@ -456,7 +599,12 @@ class SummarySpec extends UnitSpec with WithFakeApplication with MockitoSugar {
     "personal representative is chosen with a flat calculation" when {
 
       "the user has provided a value for the AEA" should {
-        val target = setupTarget(TestModels.summaryRepresentativeFlatWithAEA, TestModels.calcModelTwoRates)
+        val target = setupTarget(
+          TestModels.summaryRepresentativeFlatWithAEA,
+          TestModels.calcModelTwoRates,
+          Some(AcquisitionDateModel("Yes", Some(1), Some(1), Some(2017))),
+          None
+        )
         lazy val result = target.summary()(fakeRequest)
         lazy val document = Jsoup.parse(bodyOf(result))
 
@@ -474,7 +622,12 @@ class SummarySpec extends UnitSpec with WithFakeApplication with MockitoSugar {
       }
 
       "the user has provided no value for the AEA" should {
-        val target = setupTarget(TestModels.summaryRepresentativeFlatWithoutAEA, TestModels.calcModelTwoRates)
+        val target = setupTarget(
+          TestModels.summaryRepresentativeFlatWithoutAEA,
+          TestModels.calcModelTwoRates,
+          Some(AcquisitionDateModel("Yes", Some(1), Some(1), Some(2017))),
+          None
+        )
         lazy val result = target.summary()(fakeRequest)
         lazy val document = Jsoup.parse(bodyOf(result))
 
@@ -491,7 +644,12 @@ class SummarySpec extends UnitSpec with WithFakeApplication with MockitoSugar {
     "individual is chosen with a rebased calculation" when {
 
       "user provides no acquisition date and has two tax rates" should {
-        val target = setupTarget(TestModels.summaryIndividualRebased, TestModels.calcModelTwoRates)
+        val target = setupTarget(
+          TestModels.summaryIndividualRebased,
+          TestModels.calcModelTwoRates,
+          Some(AcquisitionDateModel("Yes", Some(1), Some(1), Some(2017))),
+          None
+        )
         lazy val result = target.summary()(fakeRequest)
         lazy val document = Jsoup.parse(bodyOf(result))
 
@@ -539,7 +697,12 @@ class SummarySpec extends UnitSpec with WithFakeApplication with MockitoSugar {
       }
 
       "user provides no acquisition date and has one tax rate" should {
-        val target = setupTarget(TestModels.summaryIndividualRebasedNoAcqDate, TestModels.calcModelOneRate)
+        val target = setupTarget(
+          TestModels.summaryIndividualRebasedNoAcqDate,
+          TestModels.calcModelOneRate,
+          Some(AcquisitionDateModel("Yes", Some(1), Some(1), Some(2017))),
+          None
+        )
         lazy val result = target.summary()(fakeRequest)
         lazy val document = Jsoup.parse(bodyOf(result))
 
@@ -557,7 +720,12 @@ class SummarySpec extends UnitSpec with WithFakeApplication with MockitoSugar {
       }
 
       "user provides acquisition date and no rebased costs" should {
-        val target = setupTarget(TestModels.summaryIndividualRebasedNoRebasedCosts, TestModels.calcModelOneRate)
+        val target = setupTarget(
+          TestModels.summaryIndividualRebasedNoRebasedCosts,
+          TestModels.calcModelOneRate,
+          Some(AcquisitionDateModel("Yes", Some(1), Some(1), Some(2017))),
+          None
+        )
         lazy val result = target.summary()(fakeRequest)
         lazy val document = Jsoup.parse(bodyOf(result))
 
@@ -567,7 +735,12 @@ class SummarySpec extends UnitSpec with WithFakeApplication with MockitoSugar {
       }
 
       "user provides no acquisition date and no rebased costs" should {
-        val target = setupTarget(TestModels.summaryIndividualRebasedNoAcqDateOrRebasedCosts, TestModels.calcModelOneRate)
+        val target = setupTarget(
+          TestModels.summaryIndividualRebasedNoAcqDateOrRebasedCosts,
+          TestModels.calcModelOneRate,
+          Some(AcquisitionDateModel("Yes", Some(1), Some(1), Some(2017))),
+          None
+        )
         lazy val result = target.summary()(fakeRequest)
         lazy val document = Jsoup.parse(bodyOf(result))
 

--- a/test/controllers/CalculationControllerTests/SummarySpec.scala
+++ b/test/controllers/CalculationControllerTests/SummarySpec.scala
@@ -641,6 +641,7 @@ class SummarySpec extends UnitSpec with WithFakeApplication with MockitoSugar {
       }
 
     }
+    
     "individual is chosen with a rebased calculation" when {
 
       "user provides no acquisition date and has two tax rates" should {
@@ -753,7 +754,12 @@ class SummarySpec extends UnitSpec with WithFakeApplication with MockitoSugar {
 
   "calling the .restart action" should {
     lazy val fakeRequest = FakeRequest("GET", "/calculate-your-capital-gains/restart").withSession(SessionKeys.sessionId -> "12345")
-    val target = setupTarget(TestModels.summaryIndividualFlatWithAEA, TestModels.calcModelTwoRates)
+    val target = setupTarget(
+      TestModels.summaryIndividualFlatWithAEA,
+      TestModels.calcModelTwoRates,
+      Some(AcquisitionDateModel("Yes", Some(1), Some(1), Some(2017))),
+      None
+    )
     lazy val result = target.restart()(fakeRequest)
     lazy val document = Jsoup.parse(bodyOf(result))
 
@@ -761,5 +767,4 @@ class SummarySpec extends UnitSpec with WithFakeApplication with MockitoSugar {
       status(result) shouldBe 303
     }
   }
-
 }


### PR DESCRIPTION
Apologies, this is a large PR - should have performed more commits.

Changed made to:

- Other Properties (Previous Taxable Gains/Disposals)
- Acquisition Date
- Improvements
- Entrepreneurs Relief
- Other reliefs
- Summary

Tests added for all permutations of user journey - including scenarios where the user jumps directly to pages and the back link can't be determined. In this scenario a new file has been introduced called DefaultRoutes with an entry "missingDataRoute" that links to the introduction page.