### PR TITLE
CGT-1107: Added the relief amount to the Calculation Election screen

### DIFF
--- a/app/constructors/CalculationElectionConstructor.scala
+++ b/app/constructors/CalculationElectionConstructor.scala
@@ -35,14 +35,24 @@ trait CalculationElectionConstructor {
   val calcConnector: CalculatorConnector
 
   //scalastyle:off
-  def generateElection(summary: SummaryModel, hc: HeaderCarrier, flatResult: Option[CalculationResultModel], timeResult: Option[CalculationResultModel], rebasedResult: Option[CalculationResultModel]): Seq[(String, String, String, Option[String], String)]= {
+  def generateElection(
+                        summary: SummaryModel,
+                        hc: HeaderCarrier,
+                        flatResult: Option[CalculationResultModel],
+                        timeResult: Option[CalculationResultModel],
+                        rebasedResult: Option[CalculationResultModel],
+                        otherReliefsFlat: Option[BigDecimal],
+                        otherReliefsTA: Option[BigDecimal],
+                        otherReliefsRebased: Option[BigDecimal]
+                      ): Seq[(String, String, String, Option[String], String, Option[BigDecimal])] = {
     summary.acquisitionDateModel.hasAcquisitionDate match {
       case "Yes" if Dates.dateAfterStart(summary.acquisitionDateModel.day.get,
         summary.acquisitionDateModel.month.get, summary.acquisitionDateModel.year.get) => {
         Seq(("flat", flatResult.get.taxOwed.setScale(2).toString(),
           Messages("calc.calculationElection.message.flat"),
           None,
-          routes.CalculationController.otherReliefs().toString()))
+          routes.CalculationController.otherReliefs().toString(),
+          otherReliefsFlat))
       }
       case "Yes" if !Dates.dateAfterStart(summary.acquisitionDateModel.day.get,
         summary.acquisitionDateModel.month.get,
@@ -53,15 +63,18 @@ trait CalculationElectionConstructor {
             ("flat", flatResult.get.taxOwed.setScale(2).toString(),
               Messages("calc.calculationElection.message.flat"),
               None,
-              routes.CalculationController.otherReliefs().toString()),
+              routes.CalculationController.otherReliefs().toString(),
+              otherReliefsFlat),
             ("time", timeResult.get.taxOwed.setScale(2).toString(),
               Messages("calc.calculationElection.message.time"),
               Some(Messages("calc.calculationElection.message.timeDate")),
-              routes.CalculationController.otherReliefsTA().toString()),
+              routes.CalculationController.otherReliefsTA().toString(),
+              otherReliefsTA),
             ("rebased", rebasedResult.get.taxOwed.setScale(2).toString(),
               Messages("calc.calculationElection.message.rebased"),
               Some(Messages("calc.calculationElection.message.rebasedDate")),
-              routes.CalculationController.otherReliefsRebased().toString())
+              routes.CalculationController.otherReliefsRebased().toString(),
+              otherReliefsRebased)
           )
         }
         else {
@@ -69,11 +82,13 @@ trait CalculationElectionConstructor {
             ("flat", flatResult.get.taxOwed.setScale(2).toString(),
               Messages("calc.calculationElection.message.flat"),
               None,
-              routes.CalculationController.otherReliefs().toString()),
+              routes.CalculationController.otherReliefs().toString(),
+              otherReliefsFlat),
             ("time", timeResult.get.taxOwed.setScale(2).toString(),
               Messages("calc.calculationElection.message.time"),
               Some(Messages("calc.calculationElection.message.timeDate")),
-              routes.CalculationController.otherReliefsTA().toString())
+              routes.CalculationController.otherReliefsTA().toString(),
+              otherReliefsTA)
           )
         }
       }
@@ -83,16 +98,21 @@ trait CalculationElectionConstructor {
             ("flat", flatResult.get.taxOwed.setScale(2).toString(),
               Messages("calc.calculationElection.message.flat"),
               None,
-              routes.CalculationController.otherReliefs().toString()),
+              routes.CalculationController.otherReliefs().toString(),
+              otherReliefsFlat),
             ("rebased", rebasedResult.get.taxOwed.setScale(2).toString(),
               Messages("calc.calculationElection.message.rebased"),
               Some(Messages("calc.calculationElection.message.rebasedDate")),
-              routes.CalculationController.otherReliefsRebased().toString())
+              routes.CalculationController.otherReliefsRebased().toString(),
+              otherReliefsRebased)
           )
         }
         else {
-          Seq(("flat", flatResult.get.taxOwed.setScale(2).toString(), Messages("calc.calculationElection.message.flat"),
-            None, routes.CalculationController.otherReliefs().toString())
+          Seq(("flat", flatResult.get.taxOwed.setScale(2).toString(),
+            Messages("calc.calculationElection.message.flat"),
+            None,
+            routes.CalculationController.otherReliefs().toString(),
+            otherReliefsFlat)
           )
         }
       }

--- a/app/views/calculation/calculationElection.scala.html
+++ b/app/views/calculation/calculationElection.scala.html
@@ -6,7 +6,10 @@
 @import uk.gov.hmrc.play.http.HeaderCarrier
 @import scala.concurrent.Future
 
-@(calculationElectionForm: Form[CalculationElectionModel], summaryModel: SummaryModel, content: Seq[(String, String, String, Option[String], String)])(implicit request: Request[_], hc: HeaderCarrier)
+@(  calculationElectionForm: Form[CalculationElectionModel],
+    summaryModel: SummaryModel,
+    content: Seq[(String, String, String, Option[String], String, Option[BigDecimal])])(implicit request: Request[_], hc: HeaderCarrier
+)
 
 @sidebar = {
     <ul>
@@ -58,7 +61,7 @@
         </div>
 
         <div class="grid-row form-group">
-            <button class="button" type="submit" id="continue-button">@Messages("calc.base.continue")</button>
+            <button class="button" name="action" value="continue" id="continue-button">@Messages("calc.base.continue")</button>
         </div>
     }
 }

--- a/app/views/helpers/calculationElectionHelperForm.scala.html
+++ b/app/views/helpers/calculationElectionHelperForm.scala.html
@@ -1,4 +1,4 @@
-@(field: Field, radioOptions: Seq[(String, String, String, Option[String], String)], args: (Symbol, Any)*)(implicit lang: play.api.i18n.Lang)
+@(field: Field, radioOptions: Seq[(String, String, String, Option[String], String, Option[BigDecimal])], args: (Symbol, Any)*)(implicit lang: play.api.i18n.Lang)
 
 @import play.api.i18n._
 @import views.html.helper._
@@ -26,7 +26,7 @@
         }
         @elements.errors.map{error => <span class="error-notification">@Messages("calc.base.optionReqError")</span>}
 
-        @radioOptions.map { case (value, amount, message, dateMessage, linkUrl) =>
+        @radioOptions.map { case (value, amount, message, dateMessage, linkUrl, otherReliefs) =>
             @defining(s"${elements.field.name}-${value.toLowerCase.replace(" ","_")}")  { inputId =>
                 <div>
                     <label for="@inputId"
@@ -46,9 +46,18 @@
                         }
                     </label>
 
-                    <div class="panel panel-indent additional-option-block">
-                        <a href=@linkUrl>@Messages("calc.calculationElection.otherRelief")</a>
-                    </div>
+                    @if(otherReliefs.isDefined){
+                        <div class="panel panel-indent additional-option-block">
+                            <span class="align-bottom">@Messages("calc.calculationElection.someOtherRelief")</span>
+                            <button id="@value-button" name="action" value="@value" class="button button--link">
+                                <span class="bold-medium">&pound;@MoneyPounds(otherReliefs.getOrElse(0)).quantity</span>
+                            </button>
+                        </div>
+                    } else {
+                        <div class="panel panel-indent additional-option-block">
+                            <button id="@value-button" name="action" value="@value" class="button button--link">@Messages("calc.calculationElection.otherRelief")</button>
+                        </div>
+                    }
                 </div>
             }
         }

--- a/conf/messages
+++ b/conf/messages
@@ -200,6 +200,7 @@ calc.calculationElection.legend = Tax you''ll owe
 calc.calculationElection.based = Based on
 calc.calculationElection.link.one = Different ways of working out Capital Gains Tax
 calc.calculationElection.otherRelief = Add other tax relief
+calc.calculationElection.someOtherRelief = Other tax relief
 calc.calculationElection.message.time = Working out your total gain, then taxing you on the percentage of it you''ve made since
 calc.calculationElection.message.timeDate = 5 April 2015
 calc.calculationElection.message.rebased = How much you''ve gained on the property since

--- a/public/stylesheets/cgt.css
+++ b/public/stylesheets/cgt.css
@@ -70,7 +70,12 @@ section {
 .additional-option-block {
     padding-left: 44px;
     border-left-width: 10px;
-    margin-bottom: 0.7894736842em
+    margin-bottom: 0.7894736842em;
+    display: table;
+}
+
+.align-bottom {
+    vertical-align: bottom;
 }
 
 .block-label input {

--- a/test/constructors/CalculationElectionConstructorSpec.scala
+++ b/test/constructors/CalculationElectionConstructorSpec.scala
@@ -50,7 +50,7 @@ class CalculationElectionConstructorSpec extends UnitSpec with MockitoSugar {
 
       "produce a single entry sequence" in {
         mockFlatCalc
-        TestCalculationElectionConstructor.generateElection(TestModels.summaryIndividualFlatWithoutAEA, hc, Some(TestModels.calcModelOneRate), Some(TestModels.calcModelOneRate), Some(TestModels.calcModelOneRate)).size shouldBe 1
+        TestCalculationElectionConstructor.generateElection(TestModels.summaryIndividualFlatWithoutAEA, hc, Some(TestModels.calcModelOneRate), Some(TestModels.calcModelOneRate), Some(TestModels.calcModelOneRate), None, None, None).size shouldBe 1
       }
     }
 
@@ -58,7 +58,7 @@ class CalculationElectionConstructorSpec extends UnitSpec with MockitoSugar {
 
       "produce a single entry sequence" in {
         mockFlatCalc
-        TestCalculationElectionConstructor.generateElection(TestModels.summaryIndividualAcqDateAfter, hc, Some(TestModels.calcModelOneRate), Some(TestModels.calcModelOneRate), Some(TestModels.calcModelOneRate)).size shouldBe 1
+        TestCalculationElectionConstructor.generateElection(TestModels.summaryIndividualAcqDateAfter, hc, Some(TestModels.calcModelOneRate), Some(TestModels.calcModelOneRate), Some(TestModels.calcModelOneRate), None, None, None).size shouldBe 1
       }
     }
 
@@ -67,20 +67,20 @@ class CalculationElectionConstructorSpec extends UnitSpec with MockitoSugar {
       "produce a two entry sequence if there is no value for rebased supplied." in {
         mockFlatCalc
         mockTimeCalc
-        TestCalculationElectionConstructor.generateElection(TestModels.summaryTrusteeTAWithoutAEA, hc, Some(TestModels.calcModelOneRate), Some(TestModels.calcModelOneRate), Some(TestModels.calcModelOneRate)).size shouldBe 2
+        TestCalculationElectionConstructor.generateElection(TestModels.summaryTrusteeTAWithoutAEA, hc, Some(TestModels.calcModelOneRate), Some(TestModels.calcModelOneRate), Some(TestModels.calcModelOneRate), None, None, None).size shouldBe 2
       }
 
       "produce a three entry sequence if there is a value for the rebased calculation supplied." in {
         mockFlatCalc
         mockTimeCalc
         mockRebasedCalc
-        TestCalculationElectionConstructor.generateElection(TestModels.summaryIndividualRebased, hc, Some(TestModels.calcModelOneRate), Some(TestModels.calcModelOneRate), Some(TestModels.calcModelOneRate)).size shouldBe 3
+        TestCalculationElectionConstructor.generateElection(TestModels.summaryIndividualRebased, hc, Some(TestModels.calcModelOneRate), Some(TestModels.calcModelOneRate), Some(TestModels.calcModelOneRate), None, None, None).size shouldBe 3
       }
 
       "produce a two entry sequence if there is a value for the rebased calculation supplied but the acquisition date is not supplied." in {
         mockFlatCalc
         mockRebasedCalc
-        TestCalculationElectionConstructor.generateElection(TestModels.summaryIndividualRebasedNoAcqDate, hc, Some(TestModels.calcModelOneRate), Some(TestModels.calcModelOneRate), Some(TestModels.calcModelOneRate)).size shouldBe 2
+        TestCalculationElectionConstructor.generateElection(TestModels.summaryIndividualRebasedNoAcqDate, hc, Some(TestModels.calcModelOneRate), Some(TestModels.calcModelOneRate), Some(TestModels.calcModelOneRate), None, None, None).size shouldBe 2
       }
     }
   }

--- a/test/controllers/CalculationControllerTests/CalculationElectionSpec.scala
+++ b/test/controllers/CalculationControllerTests/CalculationElectionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import common.TestModels
+import common.{KeystoreKeys, TestModels}
 import constructors.CalculationElectionConstructor
 import play.api.libs.json.Json
 import uk.gov.hmrc.http.cache.client.CacheMap
@@ -43,7 +43,11 @@ class CalculationElectionSpec extends UnitSpec with WithFakeApplication with Moc
   def setupTarget(getData: Option[CalculationElectionModel],
                   postData: Option[CalculationElectionModel],
                   summaryData: SummaryModel,
-                  calc: Option[CalculationResultModel] = None): CalculationController = {
+                  calc: Option[CalculationResultModel] = None,
+                  otherReliefsFlat: Option[OtherReliefsModel] = None,
+                  otherReliefsTA: Option[OtherReliefsModel] = None,
+                  otherReliefsRebased: Option[OtherReliefsModel] = None
+                 ): CalculationController = {
 
     val mockCalcConnector = mock[CalculatorConnector]
     val mockCalcElectionConstructor = mock[CalculationElectionConstructor]
@@ -51,12 +55,28 @@ class CalculationElectionSpec extends UnitSpec with WithFakeApplication with Moc
     when(mockCalcConnector.createSummary(Matchers.any()))
       .thenReturn(summaryData)
 
-    when(mockCalcElectionConstructor.generateElection(Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any()))
+    val flatReliefs = otherReliefsFlat match {
+      case Some(x) => x.otherReliefs
+      case _ => None
+    }
+    val timeReliefs = otherReliefsTA match {
+      case Some(x) => x.otherReliefs
+      case _ => None
+    }
+    val rebasedReliefs = otherReliefsRebased match {
+      case Some(x) => x.otherReliefs
+      case _ => None
+    }
+
+    when(mockCalcElectionConstructor.generateElection(Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any()))
       .thenReturn(Seq(
         ("flat", "8000.00", "flat calculation",
-          None, routes.CalculationController.otherReliefs().toString()),
+          None, routes.CalculationController.otherReliefs().toString(), flatReliefs),
         ("time", "8000.00", "time apportioned calculation",
-          Some(Messages("calc.calculationElection.message.timeDate")), routes.CalculationController.otherReliefsTA().toString())))
+          Some(Messages("calc.calculationElection.message.timeDate")), routes.CalculationController.otherReliefsTA().toString(), timeReliefs),
+        ("rebased", "10000.00", "time apportioned calculation",
+          Some(Messages("calc.calculationElection.message.timeDate")), routes.CalculationController.otherReliefsTA().toString(), rebasedReliefs)
+      ))
 
     when(mockCalcConnector.calculateFlat(Matchers.any())(Matchers.any()))
       .thenReturn(Future.successful(calc))
@@ -65,8 +85,17 @@ class CalculationElectionSpec extends UnitSpec with WithFakeApplication with Moc
     when(mockCalcConnector.calculateRebased(Matchers.any())(Matchers.any()))
       .thenReturn(Future.successful(calc))
 
-    when(mockCalcConnector.fetchAndGetFormData[CalculationElectionModel](Matchers.anyString())(Matchers.any(), Matchers.any()))
+    when(mockCalcConnector.fetchAndGetFormData[CalculationElectionModel](Matchers.eq(KeystoreKeys.calculationElection))(Matchers.any(), Matchers.any()))
       .thenReturn(Future.successful(getData))
+
+    when(mockCalcConnector.fetchAndGetFormData[OtherReliefsModel](Matchers.eq(KeystoreKeys.otherReliefsFlat))(Matchers.any(), Matchers.any()))
+      .thenReturn(Future.successful(otherReliefsFlat))
+
+    when(mockCalcConnector.fetchAndGetFormData[OtherReliefsModel](Matchers.eq(KeystoreKeys.otherReliefsTA))(Matchers.any(), Matchers.any()))
+      .thenReturn(Future.successful(otherReliefsTA))
+
+    when(mockCalcConnector.fetchAndGetFormData[OtherReliefsModel](Matchers.eq(KeystoreKeys.otherReliefsRebased))(Matchers.any(), Matchers.any()))
+      .thenReturn(Future.successful(otherReliefsRebased))
 
     lazy val data = CacheMap("form-id", Map("data" -> Json.toJson(postData.getOrElse(CalculationElectionModel("")))))
     when(mockCalcConnector.saveFormData[CalculationElectionModel](Matchers.anyString(), Matchers.any())(Matchers.any(), Matchers.any()))
@@ -224,9 +253,17 @@ class CalculationElectionSpec extends UnitSpec with WithFakeApplication with Moc
 
     }
 
-    "supplied with pre-existing data" should {
+    "supplied with pre-existing data and a value for flat, time and rebased reliefs" should {
 
-      val target = setupTarget(Some(CalculationElectionModel("flat")), None, TestModels.summaryTrusteeTAWithoutAEA)
+      val target = setupTarget(
+        Some(CalculationElectionModel("flat")),
+        None,
+        TestModels.summaryTrusteeTAWithoutAEA,
+        None,
+        Some(OtherReliefsModel(Some(500))),
+        Some(OtherReliefsModel(Some(600))),
+        Some(OtherReliefsModel(Some(700)))
+      )
       lazy val result = target.calculationElection(fakeRequest)
       lazy val document = Jsoup.parse(bodyOf(result))
 
@@ -244,6 +281,57 @@ class CalculationElectionSpec extends UnitSpec with WithFakeApplication with Moc
         "have the stored value of flat calculation selected" in {
           document.body.getElementById("calculationElection-flat").parent.classNames().contains("selected") shouldBe true
         }
+
+        "have the button text '£500.00' under flat calc details" in {
+          document.body.select("#flat-button").text shouldEqual "£500.00"
+        }
+
+        "have the button text '£600.00' under time calc details" in {
+          document.body.select("#time-button").text shouldEqual "£600.00"
+        }
+
+        s"have the button text '£500.00' under rebased calc details" in {
+          document.body.select("#rebased-button").text shouldEqual "£700.00"
+        }
+      }
+    }
+
+    "supplied with pre-existing data and no values for flat, time and rebased reliefs" should {
+
+      val target = setupTarget(
+        Some(CalculationElectionModel("flat")),
+        None,
+        TestModels.summaryTrusteeTAWithoutAEA
+      )
+      lazy val result = target.calculationElection(fakeRequest)
+      lazy val document = Jsoup.parse(bodyOf(result))
+
+      "return a 200" in {
+        status(result) shouldBe 200
+      }
+
+      "return some HTML that" should {
+
+        "contain some text and use the character set utf-8" in {
+          contentType(result) shouldBe Some("text/html")
+          charset(result) shouldBe Some("utf-8")
+        }
+
+        "have the stored value of flat calculation selected" in {
+          document.body.getElementById("calculationElection-flat").parent.classNames().contains("selected") shouldBe true
+        }
+
+        s"have the button text '${Messages("calc.calculationElection.otherRelief")}' under flat calc details" in {
+          document.body.select("#flat-button").text shouldEqual Messages("calc.calculationElection.otherRelief")
+        }
+
+        s"have the button text '${Messages("calc.calculationElection.otherRelief")}' under time calc details" in {
+          document.body.select("#time-button").text shouldEqual Messages("calc.calculationElection.otherRelief")
+        }
+
+        s"have the button text '${Messages("calc.calculationElection.otherRelief")}' under rebased calc details" in {
+          document.body.select("#rebased-button").text shouldEqual Messages("calc.calculationElection.otherRelief")
+        }
       }
     }
   }
@@ -254,16 +342,61 @@ class CalculationElectionSpec extends UnitSpec with WithFakeApplication with Moc
       .withSession(SessionKeys.sessionId -> "12345")
       .withFormUrlEncodedBody(body: _*)
 
-    def executeTargetWithMockData(data: String, calc: Option[CalculationResultModel], summary: SummaryModel): Future[Result] = {
-      lazy val fakeRequest = buildRequest(("calculationElection", data))
+    def executeTargetWithMockData
+    (
+      data: String,
+      calc: Option[CalculationResultModel],
+      summary: SummaryModel,
+      action: String
+    ): Future[Result] = {
+      lazy val fakeRequest = buildRequest(("calculationElection", data), ("action",action))
       val mockData = new CalculationElectionModel(data)
       val target = setupTarget(None, Some(mockData), summary, calc)
       target.submitCalculationElection(fakeRequest)
     }
 
+    "submitting form via Other Reliefs Flat button" should {
+
+      lazy val result = executeTargetWithMockData("flat", Some(TestModels.calcModelOneRate), TestModels.summaryTrusteeTAWithoutAEA, "flat")
+
+      "return a 303" in {
+        status(result) shouldBe 303
+      }
+
+      "redirect to the other reliefs page" in {
+        redirectLocation(result) shouldBe Some(s"${routes.CalculationController.otherReliefs()}")
+      }
+    }
+
+    "submitting form via Other Reliefs Time Apportioned button" should {
+
+      lazy val result = executeTargetWithMockData("flat", Some(TestModels.calcModelOneRate), TestModels.summaryTrusteeTAWithoutAEA, "time")
+
+      "return a 303" in {
+        status(result) shouldBe 303
+      }
+
+      "redirect to the Other Reliefs Time Apportioned page" in {
+        redirectLocation(result) shouldBe Some(s"${routes.CalculationController.otherReliefsTA()}")
+      }
+    }
+
+    "submitting form via Other Reliefs Rebased button" should {
+
+      lazy val result = executeTargetWithMockData("flat", Some(TestModels.calcModelOneRate), TestModels.summaryTrusteeTAWithoutAEA, "rebased")
+
+      "return a 303" in {
+        status(result) shouldBe 303
+      }
+
+      "redirect to the Other Reliefs Rebased page" in {
+        redirectLocation(result) shouldBe Some(s"${routes.CalculationController.otherReliefsRebased()}")
+      }
+    }
+
     "submitting a valid form with 'flat' selected" should {
 
-      lazy val result = executeTargetWithMockData("flat", Some(TestModels.calcModelOneRate), TestModels.summaryTrusteeTAWithoutAEA)
+      lazy val result = executeTargetWithMockData("flat", Some(TestModels.calcModelOneRate), TestModels.summaryTrusteeTAWithoutAEA, "continue")
 
       "return a 303" in {
         status(result) shouldBe 303
@@ -276,7 +409,7 @@ class CalculationElectionSpec extends UnitSpec with WithFakeApplication with Moc
 
     "submitting a valid form with 'time' selected" should {
 
-      lazy val result = executeTargetWithMockData("time", Some(TestModels.calcModelOneRate), TestModels.summaryIndividualAcqDateAfter)
+      lazy val result = executeTargetWithMockData("time", Some(TestModels.calcModelOneRate), TestModels.summaryIndividualAcqDateAfter, "continue")
 
       "return a 303" in {
         status(result) shouldBe 303
@@ -285,7 +418,7 @@ class CalculationElectionSpec extends UnitSpec with WithFakeApplication with Moc
 
     "submitting a valid form with 'rebased' selected" should {
 
-      lazy val result = executeTargetWithMockData("rebased", Some(TestModels.calcModelOneRate), TestModels.summaryIndividualFlatWithAEA)
+      lazy val result = executeTargetWithMockData("rebased", Some(TestModels.calcModelOneRate), TestModels.summaryIndividualFlatWithAEA, "continue")
 
       "return a 303" in {
         status(result) shouldBe 303
@@ -294,7 +427,7 @@ class CalculationElectionSpec extends UnitSpec with WithFakeApplication with Moc
 
     "submitting a form with no data" should  {
 
-      lazy val result = executeTargetWithMockData("", Some(TestModels.calcModelOneRate), TestModels.summaryIndividualImprovementsWithRebasedModel)
+      lazy val result = executeTargetWithMockData("", Some(TestModels.calcModelOneRate), TestModels.summaryIndividualImprovementsWithRebasedModel, "continue")
       lazy val document = Jsoup.parse(bodyOf(result))
 
       "return a 400" in {
@@ -312,7 +445,7 @@ class CalculationElectionSpec extends UnitSpec with WithFakeApplication with Moc
 
     "submitting a form with completely unrelated 'ew1234qwer'" should  {
 
-      lazy val result = executeTargetWithMockData("ew1234qwer", Some(TestModels.calcModelOneRate), TestModels.summaryIndividualImprovementsNoRebasedModel)
+      lazy val result = executeTargetWithMockData("ew1234qwer", Some(TestModels.calcModelOneRate), TestModels.summaryIndividualImprovementsNoRebasedModel, "continue")
 
       "return a 400" in {
         status(result) shouldBe 400
@@ -320,7 +453,7 @@ class CalculationElectionSpec extends UnitSpec with WithFakeApplication with Moc
     }
 
     "submitting an invalid form with an acquisition date after the tax start date" should {
-      lazy val result = executeTargetWithMockData("", Some(TestModels.calcModelOneRate), TestModels.summaryIndividualAcqDateAfter)
+      lazy val result = executeTargetWithMockData("", Some(TestModels.calcModelOneRate), TestModels.summaryIndividualAcqDateAfter, "continue")
 
       "return a 400" in {
         status(result) shouldBe 400
@@ -328,7 +461,7 @@ class CalculationElectionSpec extends UnitSpec with WithFakeApplication with Moc
     }
 
     "submitting an invalid form with no acquisition date" should {
-      lazy val result = executeTargetWithMockData("", Some(TestModels.calcModelOneRate), TestModels.summaryIndividualFlatWithoutAEA)
+      lazy val result = executeTargetWithMockData("", Some(TestModels.calcModelOneRate), TestModels.summaryIndividualFlatWithoutAEA, "continue")
 
       "return a 400" in {
         status(result) shouldBe 400
@@ -336,7 +469,7 @@ class CalculationElectionSpec extends UnitSpec with WithFakeApplication with Moc
     }
 
     "submitting an invalid form with none rebased value" should {
-      lazy val result = executeTargetWithMockData("", Some(TestModels.calcModelOneRate), TestModels.summaryIndividualImprovementsNoRebasedModel)
+      lazy val result = executeTargetWithMockData("", Some(TestModels.calcModelOneRate), TestModels.summaryIndividualImprovementsNoRebasedModel, "continue")
 
       "return a 400" in {
         status(result) shouldBe 400
@@ -344,7 +477,7 @@ class CalculationElectionSpec extends UnitSpec with WithFakeApplication with Moc
     }
 
     "submitting an invalid form with a rebased value and no acquisition date" should {
-      lazy val result = executeTargetWithMockData("", Some(TestModels.calcModelOneRate), TestModels.summaryIndividualRebasedNoAcqDateOrRebasedCosts)
+      lazy val result = executeTargetWithMockData("", Some(TestModels.calcModelOneRate), TestModels.summaryIndividualRebasedNoAcqDateOrRebasedCosts, "continue")
 
       "return a 400" in {
         status(result) shouldBe 400
@@ -352,7 +485,7 @@ class CalculationElectionSpec extends UnitSpec with WithFakeApplication with Moc
     }
 
     "submitting an invalid form with a rebased value and an acquisition date after tax start" should {
-      lazy val result = executeTargetWithMockData("", Some(TestModels.calcModelOneRate), TestModels.summaryIndividualRebasedAcqDateAfter)
+      lazy val result = executeTargetWithMockData("", Some(TestModels.calcModelOneRate), TestModels.summaryIndividualRebasedAcqDateAfter, "continue")
 
       "return a 400" in {
         status(result) shouldBe 400


### PR DESCRIPTION
A number of changes have been made to meet this.

- The relief amounts are retrieved from keystore and the values sent to generateElection action of the calcElectionConstructor.
- The constructor has been amended to add the appropriate reliefs amount to the returned sequence
- The helper to generate the election radio option has been amended to output the appropriate message if an amount is defined.
- The anchor <a> links on Calculation Election have been changed to buttons. These submit the form with an 'action'. This action is then read by the controller to determine where the route should redirect to. For example, if the 'time' action is sent then it redirects to otherReliefsTA. Whereas if the 'continue' action is sent then it redirects to the summary.