### PR TITLE
CGT-1149 fixed fieldset/legend pairing

### DIFF
--- a/app/views/calculation/otherProperties.scala.html
+++ b/app/views/calculation/otherProperties.scala.html
@@ -42,24 +42,26 @@
 
     @form(action = routes.CalculationController.submitOtherProperties) {
 
-        <legend>
-            <p>@Messages("calc.otherProperties.question")</p>
-            <p>@Messages("calc.otherProperties.thisIncludes")</p>
+        <fieldset>
+            <legend>
+                <p>@Messages("calc.otherProperties.question")</p>
+                <p>@Messages("calc.otherProperties.thisIncludes")</p>
+            </legend>
             <ul class="list list-bullet">
                 <li>@Messages("calc.otherProperties.thisIncludes.bulletOne")</li>
                 <li>@Messages("calc.otherProperties.thisIncludes.bulletTwo")</li>
                 <li>@Messages("calc.otherProperties.thisIncludes.bulletThree")</li>
             </ul>
-        </legend>
-        <div class="inline form-group">
-            @formHiddenYesNoRadio(
-                otherPropertiesForm,
-                "otherProperties",
-                "",
-                hiddenYesNoContent
-            )
+            <div class="inline form-group">
+                @formHiddenYesNoRadio(
+                    otherPropertiesForm,
+                    "otherProperties",
+                    "",
+                    hiddenYesNoContent
+                )
 
-        </div>
+            </div>
+        </fieldset>
         <button class="button" type="submit" id="continue-button" >@Messages("calc.base.continue")</button>
     }
 }

--- a/app/views/helpers/formInlineDateInput.scala.html
+++ b/app/views/helpers/formInlineDateInput.scala.html
@@ -10,16 +10,16 @@
 
 <fieldset class="form-group form-date @fieldsetClasses" id="@fieldName-fieldset">
 
+    <legend>
+        @questionText
+    </legend>
+
     @if(formItem.hasErrors) {
         @formItem.errors.filter(_.key == "").map { error => <span class="error-notification">@error.message</span>}
         @if(formItem.errors.find(_.key != "").isDefined) {
             <span class="error-notification">@Messages("calc.common.date.error.invalidDate")</span>
         }
     }
-
-    <legend>
-        @questionText
-    </legend>
 
     <span class="form-hint">@Messages("calc.common.date.hint")</span>
 


### PR DESCRIPTION
- This affects other properties, disposal date, acquisition date pages
- There was a comment in the DAC report about disabled trustee page - I couldn't find the problem in this page as the fieldset and legend appear to be paired correctly in the formInputRadioGroup helper and unfortunately we're unable to test this without the same tools - therefore disabled trustee is unchanged