### PR TITLE
CGT-1297: Added route, action and blank HTML for Acquisition Value

### DIFF
--- a/app/controllers/resident/GainController.scala
+++ b/app/controllers/resident/GainController.scala
@@ -44,6 +44,7 @@ trait GainController extends FeatureLock {
   val acquisitionValue = FeatureLockForRTT.async { implicit request =>
     Future.successful(Ok(views.acquisitionValue()))
   }
+  
   val disposalCosts = FeatureLockForRTT.async { implicit request =>
     Future.successful(Ok(views.disposalCosts()))
   }

--- a/app/controllers/resident/GainController.scala
+++ b/app/controllers/resident/GainController.scala
@@ -42,7 +42,7 @@ trait GainController extends FeatureLock {
   }
 
   val acquisitionValue = FeatureLockForRTT.async { implicit request =>
-    Future.successful(Ok(""))
+    Future.successful(Ok(views.acquisitionValue()))
   }
   val disposalCosts = FeatureLockForRTT.async { implicit request =>
     Future.successful(Ok(views.disposalCosts()))

--- a/app/controllers/resident/GainController.scala
+++ b/app/controllers/resident/GainController.scala
@@ -41,5 +41,7 @@ trait GainController extends FeatureLock {
     Future.successful(Ok(views.disposalValue()))
   }
 
-  val acquisitionValue = TODO
+  val acquisitionValue = FeatureLockForRTT.async { implicit request =>
+    Future.successful(Ok(""))
+  }
 }

--- a/app/controllers/resident/GainController.scala
+++ b/app/controllers/resident/GainController.scala
@@ -40,4 +40,6 @@ trait GainController extends FeatureLock {
   val disposalValue = FeatureLockForRTT.async { implicit request =>
     Future.successful(Ok(views.disposalValue()))
   }
+
+  val acquisitionValue = TODO
 }

--- a/app/views/calculation/resident/acquisitionValue.scala.html
+++ b/app/views/calculation/resident/acquisitionValue.scala.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>AcquisitionValue</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/conf/res.routes
+++ b/conf/res.routes
@@ -9,6 +9,7 @@ GET     /disposal-value                   controllers.resident.GainController.di
 #Disposal Costs Routes
 
 #Acquisition Value or Market Value Routes
+GET     /acquisition-value                controllers.resident.GainController.acquisitionValue
 
 #Acquisition Costs Routes
 

--- a/test/controllers/helpers/FakeRequestHelper.scala
+++ b/test/controllers/helpers/FakeRequestHelper.scala
@@ -21,5 +21,5 @@ import uk.gov.hmrc.play.http.SessionKeys
 
 trait FakeRequestHelper {
   lazy val fakeRequest = FakeRequest()
-  lazy val fakeRequstWithSession = fakeRequest.withSession((SessionKeys.sessionId, ""))
+  lazy val fakeRequestWithSession = fakeRequest.withSession((SessionKeys.sessionId, ""))
 }

--- a/test/controllers/helpers/FakeRequestHelper.scala
+++ b/test/controllers/helpers/FakeRequestHelper.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.helpers
+
+import play.api.test.FakeRequest
+import uk.gov.hmrc.play.http.SessionKeys
+
+trait FakeRequestHelper {
+  lazy val fakeRequest = FakeRequest()
+  lazy val fakeRequstWithSession = fakeRequest.withSession((SessionKeys.sessionId, ""))
+}

--- a/test/controllers/resident/GainControllerTests/AcquisitionValueActionSpec.scala
+++ b/test/controllers/resident/GainControllerTests/AcquisitionValueActionSpec.scala
@@ -24,7 +24,7 @@ class AcquisitionValueActionSpec extends UnitSpec with WithFakeApplication with 
 
   "Calling .acquisitionCosts from the GainCalculationController with session" should {
 
-    lazy val result = GainController.acquisitionValue(fakeRequstWithSession)
+    lazy val result = GainController.acquisitionValue(fakeRequestWithSession)
 
     "return a status of 200" in {
       status(result) shouldBe 200

--- a/test/controllers/resident/GainControllerTests/AcquisitionValueActionSpec.scala
+++ b/test/controllers/resident/GainControllerTests/AcquisitionValueActionSpec.scala
@@ -15,23 +15,33 @@
  */
 
 package controllers.resident.GainControllerTests
+
 import controllers.helpers.FakeRequestHelper
 import controllers.resident.GainController
+import org.jsoup.Jsoup
 import play.api.test.Helpers._
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 
 class AcquisitionValueActionSpec extends UnitSpec with WithFakeApplication with FakeRequestHelper {
 
-  "Calling .acquisitionCosts from the GainCalculationController with session" should {
+  "Calling .acquisitionValue from the GainCalculationController with session" should {
 
     lazy val result = GainController.acquisitionValue(fakeRequestWithSession)
 
     "return a status of 200" in {
       status(result) shouldBe 200
     }
+
+    "return some html" in {
+      contentType(result) shouldBe Some("text/html")
+    }
+
+    "display the Acquisition Value view" in {
+      Jsoup.parse(bodyOf(result)).title shouldBe "AcquisitionValue"
+    }
   }
 
-  "Calling .acquisitionCosts from the GainCalculationController with no session" should {
+  "Calling .acquisitionValue from the GainCalculationController with no session" should {
 
     lazy val result = GainController.acquisitionValue(fakeRequest)
 

--- a/test/controllers/resident/GainControllerTests/AcquisitionValueActionSpec.scala
+++ b/test/controllers/resident/GainControllerTests/AcquisitionValueActionSpec.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.resident.GainControllerTests
+import controllers.helpers.FakeRequestHelper
+import controllers.resident.GainController
+import play.api.test.Helpers._
+import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+
+class AcquisitionValueActionSpec extends UnitSpec with WithFakeApplication with FakeRequestHelper {
+
+  "Calling .acquisitionCosts from the GainCalculationController with session" should {
+
+    lazy val result = GainController.acquisitionValue(fakeRequstWithSession)
+
+    "return a status of 200" in {
+      status(result) shouldBe 200
+    }
+  }
+
+  "Calling .acquisitionCosts from the GainCalculationController with no session" should {
+
+    lazy val result = GainController.acquisitionValue(fakeRequest)
+
+    "return a status of 303" in {
+      status(result) shouldBe 303
+    }
+
+    "return you to the session timeout view" in {
+      redirectLocation(result).get shouldBe "/calculate-your-capital-gains/non-resident/session-timeout"
+    }
+  }
+}

--- a/test/controllers/resident/GainControllerTests/DisposalDateActionSpec.scala
+++ b/test/controllers/resident/GainControllerTests/DisposalDateActionSpec.scala
@@ -17,32 +17,30 @@
 package controllers.resident.GainControllerTests
 
 import controllers.resident.GainController
-import play.api.test.FakeRequest
+import controllers.helpers.FakeRequestHelper
 import play.api.test.Helpers._
-import uk.gov.hmrc.play.http.SessionKeys
 import uk.gov.hmrc.play.test.{WithFakeApplication, UnitSpec}
 
-class DisposalDateActionSpec extends UnitSpec with WithFakeApplication {
+class DisposalDateActionSpec extends UnitSpec with WithFakeApplication with FakeRequestHelper {
 
   "Calling .disposalDate from the GainCalculationController" should {
 
+    lazy val result = GainController.disposalDate(fakeRequstWithSession)
+
     "return a status of 200" in {
-      val fakeRequest = FakeRequest("GET", "").withSession((SessionKeys.sessionId, ""))
-      val result = GainController.disposalDate(fakeRequest)
       status(result) shouldBe 200
     }
 
     "return some html" in {
-      val fakeRequest = FakeRequest("GET", "").withSession((SessionKeys.sessionId, ""))
-      val result = GainController.disposalDate(fakeRequest)
       contentType(result) shouldBe Some("text/html")
     }
   }
 
   "Calling .disposalDate from the GainCalculationController with no session" should {
+
+    lazy val result = GainController.disposalDate(fakeRequest)
+
     "return a status of 200" in {
-      val fakeRequest = FakeRequest("GET", "")
-      val result = GainController.disposalDate(fakeRequest)
       status(result) shouldBe 200
     }
   }

--- a/test/controllers/resident/GainControllerTests/DisposalDateActionSpec.scala
+++ b/test/controllers/resident/GainControllerTests/DisposalDateActionSpec.scala
@@ -25,7 +25,7 @@ class DisposalDateActionSpec extends UnitSpec with WithFakeApplication with Fake
 
   "Calling .disposalDate from the GainCalculationController" should {
 
-    lazy val result = GainController.disposalDate(fakeRequstWithSession)
+    lazy val result = GainController.disposalDate(fakeRequestWithSession)
 
     "return a status of 200" in {
       status(result) shouldBe 200

--- a/test/controllers/resident/GainControllerTests/DisposalValueActionSpec.scala
+++ b/test/controllers/resident/GainControllerTests/DisposalValueActionSpec.scala
@@ -17,34 +17,31 @@
 package controllers.resident.GainControllerTests
 
 import controllers.resident.GainController
-import play.api.test.FakeRequest
+import controllers.helpers.FakeRequestHelper
 import play.api.test.Helpers._
-import uk.gov.hmrc.play.http.SessionKeys
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 
-class DisposalValueActionSpec extends UnitSpec with WithFakeApplication {
+class DisposalValueActionSpec extends UnitSpec with WithFakeApplication with FakeRequestHelper {
 
   "Calling .disposalValue from the GainCalculationController" should {
+
+    lazy val result = GainController.disposalValue(fakeRequstWithSession)
+
     "return a status of 200" in {
-      val fakeRequest = FakeRequest("GET", "/").withSession((SessionKeys.sessionId, ""))
-      val result = GainController.disposalValue(fakeRequest)
       status(result) shouldBe 200
+    }
+
+    "return some html" in {
+      contentType(result) shouldBe Some("text/html")
     }
   }
 
   "Calling .disposalValue from the GainCalculationController with no session" should {
-    "return a status of 303" in {
-      val fakeRequest = FakeRequest("GET", "")
-      val result = GainController.disposalValue(fakeRequest)
-      status(result) shouldBe 303
-    }
-  }
 
-  "Calling .disposalValue from the GainCalculationController" should {
-    "return some html" in {
-      val fakeRequest = FakeRequest("GET", "").withSession((SessionKeys.sessionId, ""))
-      val result = GainController.disposalValue(fakeRequest)
-      contentType(result) shouldBe Some("text/html")
+    lazy val result = GainController.disposalValue(fakeRequest)
+
+    "return a status of 303" in {
+      status(result) shouldBe 303
     }
   }
 }

--- a/test/controllers/resident/GainControllerTests/DisposalValueActionSpec.scala
+++ b/test/controllers/resident/GainControllerTests/DisposalValueActionSpec.scala
@@ -25,7 +25,7 @@ class DisposalValueActionSpec extends UnitSpec with WithFakeApplication with Fak
 
   "Calling .disposalValue from the GainCalculationController" should {
 
-    lazy val result = GainController.disposalValue(fakeRequstWithSession)
+    lazy val result = GainController.disposalValue(fakeRequestWithSession)
 
     "return a status of 200" in {
       status(result) shouldBe 200

--- a/test/routes/RoutesSpec.scala
+++ b/test/routes/RoutesSpec.scala
@@ -34,4 +34,11 @@ class RoutesSpec extends UnitSpec with WithFakeApplication with Matchers {
       path shouldEqual "/calculate-your-capital-gains/resident/disposal-value"
     }
   }
+
+  "The URL for the acquisition value or market value Action" should {
+    "be equal to /calculate-your-capital-gains/resident/acquisition-value" in {
+      val path = controllers.resident.routes.GainController.acquisitionValue.toString()
+      path shouldEqual "/calculate-your-capital-gains/resident/acquisition-value"
+    }
+  }
 }

--- a/test/views/resident/AcquisitionValueViewSpec.scala
+++ b/test/views/resident/AcquisitionValueViewSpec.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.resident
+
+import org.jsoup.Jsoup
+import uk.gov.hmrc.play.test.{WithFakeApplication, UnitSpec}
+
+class AcquisitionValueViewSpec extends UnitSpec with WithFakeApplication {
+
+  "Acquisition Value view" should {
+
+    lazy val view = views.html.calculation.resident.acquisitionValue()
+    lazy val doc = Jsoup.parse(view.body)
+
+    "have charset UTF-8" in {
+      doc.charset().toString shouldBe "UTF-8"
+    }
+
+    "have title AcquisitionValue" in {
+      doc.title shouldBe "AcquisitionValue"
+    }
+  }
+}


### PR DESCRIPTION
Additional refactor to introduce a **FakeRequstHelper** trait which the test controller specs extend.

This trait contains a **fakeRequest** and **fakeRequestWithSession** lazy vals which can be used controller test specs. This removes some code duplication.

Also refactored to have a lazy val for the result in the controller specs to reduce code duplication.