### PR TITLE
Updated routing from AEA/brought forward losses/brought forward losses value

### DIFF
--- a/app/controllers/resident/DeductionsController.scala
+++ b/app/controllers/resident/DeductionsController.scala
@@ -320,7 +320,7 @@ trait DeductionsController extends FeatureLock {
   }
 
   def positiveAEACheck(model: AnnualExemptAmountModel)(implicit hc: HeaderCarrier): Future[Boolean] = {
-    Future(model.amount > 0gs)
+    Future(model.amount > 0)
   }
 
   val submitAnnualExemptAmount = FeatureLockForRTT.async { implicit request =>

--- a/test/controllers/resident/DeductionsControllerTests/AnnualExemptAmountActionSpec.scala
+++ b/test/controllers/resident/DeductionsControllerTests/AnnualExemptAmountActionSpec.scala
@@ -20,7 +20,7 @@ import common.KeystoreKeys
 import connectors.CalculatorConnector
 import controllers.helpers.FakeRequestHelper
 import controllers.resident.DeductionsController
-import models.resident.AnnualExemptAmountModel
+import models.resident.{ChargeableGainResultModel, ChargeableGainAnswers, YourAnswersSummaryModel, AnnualExemptAmountModel}
 import org.jsoup.Jsoup
 import org.mockito.Matchers
 import org.scalatest.mock.MockitoSugar
@@ -30,19 +30,43 @@ import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 
 import scala.concurrent.Future
 
-class AnnualExemptAmountActionSpec extends UnitSpec with WithFakeApplication with FakeRequestHelper with MockitoSugar{
-  def setupTarget(getData: Option[AnnualExemptAmountModel]): DeductionsController = {
+class AnnualExemptAmountActionSpec extends UnitSpec with WithFakeApplication with FakeRequestHelper with MockitoSugar {
+
+  val gainModel = mock[YourAnswersSummaryModel]
+  val summaryModel = mock[ChargeableGainAnswers]
+  val chargeableGainModel = mock[ChargeableGainResultModel]
+
+  def setupTarget(getData: Option[AnnualExemptAmountModel],
+                  gainAnswers: YourAnswersSummaryModel,
+                  chargeableGainAnswers: ChargeableGainAnswers,
+                  chargeableGain: ChargeableGainResultModel): DeductionsController = {
+
     val mockCalcConnector = mock[CalculatorConnector]
+
     when(mockCalcConnector.fetchAndGetFormData[AnnualExemptAmountModel](Matchers.eq(KeystoreKeys.ResidentKeys.annualExemptAmount))(Matchers.any(), Matchers.any()))
       .thenReturn(Future.successful(getData))
+
+    when(mockCalcConnector.getYourAnswers(Matchers.any()))
+      .thenReturn(Future.successful(gainAnswers))
+
+    when(mockCalcConnector.getChargeableGainAnswers(Matchers.any()))
+      .thenReturn(Future.successful(chargeableGainAnswers))
+
+    when(mockCalcConnector.calculateRttChargeableGain(Matchers.any(), Matchers.any(), Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Some(chargeableGain)))
+
     new DeductionsController {
       override val calcConnector: CalculatorConnector = mockCalcConnector
     }
   }
+
   "Calling .annualExemptAmount from the DeductionsController" when {
+
     "there is no keystore data" should {
-      lazy val target = setupTarget(None)
+
+      lazy val target = setupTarget(None, gainModel, summaryModel, chargeableGainModel)
       lazy val result = target.annualExemptAmount(fakeRequestWithSession)
+
       "return a status of 200" in {
         status(result) shouldBe 200
       }
@@ -53,47 +77,93 @@ class AnnualExemptAmountActionSpec extends UnitSpec with WithFakeApplication wit
         Jsoup.parse(bodyOf(result)).title shouldBe messages.title
       }
     }
+
     "there is some keystore data" should {
-      lazy val target = setupTarget(Some(AnnualExemptAmountModel(1000)))
+
+      lazy val target = setupTarget(Some(AnnualExemptAmountModel(1000)), gainModel, summaryModel, chargeableGainModel)
       lazy val result = target.annualExemptAmount(fakeRequestWithSession)
+
       "return a status of 200" in {
         status(result) shouldBe 200
       }
+
       "return some html" in {
         contentType(result) shouldBe Some("text/html")
       }
+
       "display the Annual Exempt Amount view" in {
         Jsoup.parse(bodyOf(result)).title shouldBe messages.title
       }
     }
   }
+
   "request has an invalid session" should {
+
     lazy val result = DeductionsController.annualExemptAmount(fakeRequest)
+
     "return a status of 303" in {
       status(result) shouldBe 303
     }
+
     "return you to the session timeout page" in {
       redirectLocation(result) shouldBe Some("/calculate-your-capital-gains/non-resident/session-timeout")
     }
   }
+
   "Calling .submitAnnualExemptAmount from the DeductionsController" when {
-    "a valid form is submitted" should {
+
+    "a valid form is submitted with AEA of 1000 and zero taxable gain" should {
+      lazy val target = setupTarget(Some(AnnualExemptAmountModel(1000)), gainModel, summaryModel, ChargeableGainResultModel(2000, 0, 1000, 1000))
       lazy val request = fakeRequestToPOSTWithSession(("amount", "1000"))
-      lazy val result = DeductionsController.submitAnnualExemptAmount(request)
+      lazy val result = target.submitAnnualExemptAmount(request)
+
       "return a 303" in {
         status(result) shouldBe 303
       }
+
       "redirect to the summary page" in {
         redirectLocation(result) shouldBe Some("/calculate-your-capital-gains/resident/summary")
       }
     }
+
+    "a valid form is submitted with AEA of 0 and positive taxable gain" should {
+      lazy val target = setupTarget(Some(AnnualExemptAmountModel(0)), gainModel, summaryModel, ChargeableGainResultModel(1000, 1000, 0, 0))
+      lazy val request = fakeRequestToPOSTWithSession(("amount", "0"))
+      lazy val result = target.submitAnnualExemptAmount(request)
+
+      "return a 303" in {
+        status(result) shouldBe 303
+      }
+
+      "redirect to the previous taxable gains page" in {
+        redirectLocation(result) shouldBe Some("/calculate-your-capital-gains/resident/previous-taxable-gains")
+      }
+    }
+
+    "a valid form is submitted with AEA of 1000 and positive taxable gain" should {
+      lazy val target = setupTarget(Some(AnnualExemptAmountModel(1000)), gainModel, summaryModel, ChargeableGainResultModel(2000, 1000, 1000, 0))
+      lazy val request = fakeRequestToPOSTWithSession(("amount", "1000"))
+      lazy val result = target.submitAnnualExemptAmount(request)
+
+      "return a 303" in {
+        status(result) shouldBe 303
+      }
+
+      "redirect to the summary page" in {
+        redirectLocation(result) shouldBe Some("/calculate-your-capital-gains/resident/current-income")
+      }
+    }
+
     "an invalid form is submitted" should {
+
       lazy val request = fakeRequestToPOSTWithSession(("amount", ""))
       lazy val result = DeductionsController.submitAnnualExemptAmount(request)
       lazy val doc = Jsoup.parse(bodyOf(result))
+
       "return a 400" in {
         status(result) shouldBe 400
       }
+
       "render the annual exempt amount page" in {
         doc.title() shouldEqual messages.title
       }

--- a/test/controllers/resident/DeductionsControllerTests/AnnualExemptAmountActionSpec.scala
+++ b/test/controllers/resident/DeductionsControllerTests/AnnualExemptAmountActionSpec.scala
@@ -16,16 +16,17 @@
 
 package controllers.resident.DeductionsControllerTests
 import assets.MessageLookup.{annualExemptAmount => messages}
-import common.KeystoreKeys
+import common.KeystoreKeys.{ResidentKeys => keystoreKeys}
 import connectors.CalculatorConnector
 import controllers.helpers.FakeRequestHelper
 import controllers.resident.DeductionsController
-import models.resident.{ChargeableGainResultModel, ChargeableGainAnswers, YourAnswersSummaryModel, AnnualExemptAmountModel}
+import models.resident.{AnnualExemptAmountModel, ChargeableGainAnswers, ChargeableGainResultModel, YourAnswersSummaryModel}
 import org.jsoup.Jsoup
 import org.mockito.Matchers
 import org.scalatest.mock.MockitoSugar
 import org.mockito.Mockito._
 import play.api.test.Helpers._
+import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 
 import scala.concurrent.Future
@@ -43,8 +44,11 @@ class AnnualExemptAmountActionSpec extends UnitSpec with WithFakeApplication wit
 
     val mockCalcConnector = mock[CalculatorConnector]
 
-    when(mockCalcConnector.fetchAndGetFormData[AnnualExemptAmountModel](Matchers.eq(KeystoreKeys.ResidentKeys.annualExemptAmount))(Matchers.any(), Matchers.any()))
+    when(mockCalcConnector.fetchAndGetFormData[AnnualExemptAmountModel](Matchers.eq(keystoreKeys.annualExemptAmount))(Matchers.any(), Matchers.any()))
       .thenReturn(Future.successful(getData))
+
+    when(mockCalcConnector.saveFormData[AnnualExemptAmountModel](Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any()))
+      .thenReturn(Future.successful(mock[CacheMap]))
 
     when(mockCalcConnector.getYourAnswers(Matchers.any()))
       .thenReturn(Future.successful(gainAnswers))
@@ -95,18 +99,18 @@ class AnnualExemptAmountActionSpec extends UnitSpec with WithFakeApplication wit
         Jsoup.parse(bodyOf(result)).title shouldBe messages.title
       }
     }
-  }
 
-  "request has an invalid session" should {
+    "request has an invalid session" should {
 
-    lazy val result = DeductionsController.annualExemptAmount(fakeRequest)
+      lazy val result = DeductionsController.annualExemptAmount(fakeRequest)
 
-    "return a status of 303" in {
-      status(result) shouldBe 303
-    }
+      "return a status of 303" in {
+        status(result) shouldBe 303
+      }
 
-    "return you to the session timeout page" in {
-      redirectLocation(result) shouldBe Some("/calculate-your-capital-gains/non-resident/session-timeout")
+      "return you to the session timeout page" in {
+        redirectLocation(result) shouldBe Some("/calculate-your-capital-gains/non-resident/session-timeout")
+      }
     }
   }
 

--- a/test/controllers/resident/DeductionsControllerTests/LossesBroughtForwardActionSpec.scala
+++ b/test/controllers/resident/DeductionsControllerTests/LossesBroughtForwardActionSpec.scala
@@ -32,9 +32,16 @@ import scala.concurrent.Future
 
 class LossesBroughtForwardActionSpec extends UnitSpec with WithFakeApplication with FakeRequestHelper with MockitoSugar {
 
+  val gainModel = mock[YourAnswersSummaryModel]
+  val summaryModel = mock[ChargeableGainAnswers]
+  val chargeableGainModel = mock[ChargeableGainResultModel]
+
   def setupTarget(lossesBroughtForwardData: Option[LossesBroughtForwardModel],
                    otherPropertiesData: Option[OtherPropertiesModel],
-                  allowableLossesData: Option[AllowableLossesModel] ): DeductionsController = {
+                   allowableLossesData: Option[AllowableLossesModel],
+                   gainAnswers: YourAnswersSummaryModel,
+                   chargeableGainAnswers: ChargeableGainAnswers,
+                   chargeableGain: ChargeableGainResultModel): DeductionsController = {
 
     val mockCalcConnector = mock[CalculatorConnector]
 
@@ -48,6 +55,15 @@ class LossesBroughtForwardActionSpec extends UnitSpec with WithFakeApplication w
     when(mockCalcConnector.fetchAndGetFormData[AllowableLossesModel](Matchers.eq(KeystoreKeys.ResidentKeys.allowableLosses))(Matchers.any(), Matchers.any()))
       .thenReturn(Future.successful(allowableLossesData))
 
+    when(mockCalcConnector.getYourAnswers(Matchers.any()))
+      .thenReturn(Future.successful(gainAnswers))
+
+    when(mockCalcConnector.getChargeableGainAnswers(Matchers.any()))
+      .thenReturn(Future.successful(chargeableGainAnswers))
+
+    when(mockCalcConnector.calculateRttChargeableGain(Matchers.any(), Matchers.any(), Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Some(chargeableGain)))
+
     new DeductionsController {
       override val calcConnector: CalculatorConnector = mockCalcConnector
     }
@@ -57,7 +73,7 @@ class LossesBroughtForwardActionSpec extends UnitSpec with WithFakeApplication w
 
     "request has a valid session and no keystore value" should {
 
-    lazy val target = setupTarget(None, Some(OtherPropertiesModel(false)), None)
+    lazy val target = setupTarget(None, Some(OtherPropertiesModel(false)), None, gainModel, summaryModel, chargeableGainModel)
     lazy val result = target.lossesBroughtForward(fakeRequestWithSession)
     lazy val doc = Jsoup.parse(bodyOf(result))
 
@@ -76,7 +92,7 @@ class LossesBroughtForwardActionSpec extends UnitSpec with WithFakeApplication w
 
     "request has no session" should {
 
-      lazy val target = setupTarget(None, None, None)
+      lazy val target = setupTarget(None, None, None, gainModel, summaryModel, chargeableGainModel)
       lazy val result = target.lossesBroughtForward(fakeRequest)
 
       "return a status of 303" in {
@@ -86,7 +102,7 @@ class LossesBroughtForwardActionSpec extends UnitSpec with WithFakeApplication w
 
     "no other properties have been selected" should {
 
-      lazy val target = setupTarget(None, Some(OtherPropertiesModel(false)), None)
+      lazy val target = setupTarget(None, Some(OtherPropertiesModel(false)), None, gainModel, summaryModel, chargeableGainModel)
       lazy val result = target.lossesBroughtForward(fakeRequestWithSession)
       lazy val doc = Jsoup.parse(bodyOf(result))
 
@@ -101,7 +117,7 @@ class LossesBroughtForwardActionSpec extends UnitSpec with WithFakeApplication w
 
     "other properties have been selected" should {
 
-      lazy val target = setupTarget(None, Some(OtherPropertiesModel(true)), None)
+      lazy val target = setupTarget(None, Some(OtherPropertiesModel(true)), None, gainModel, summaryModel, chargeableGainModel)
       lazy val result = target.lossesBroughtForward(fakeRequestWithSession)
       lazy val doc = Jsoup.parse(bodyOf(result))
 
@@ -116,7 +132,7 @@ class LossesBroughtForwardActionSpec extends UnitSpec with WithFakeApplication w
 
     "other properties have been selected but no allowable losses" should {
 
-      lazy val target = setupTarget(None, Some(OtherPropertiesModel(true)), Some(AllowableLossesModel(false)))
+      lazy val target = setupTarget(None, Some(OtherPropertiesModel(true)), Some(AllowableLossesModel(false)), gainModel, summaryModel, chargeableGainModel)
       lazy val result = target.lossesBroughtForward(fakeRequestWithSession)
       lazy val doc = Jsoup.parse(bodyOf(result))
 
@@ -131,7 +147,7 @@ class LossesBroughtForwardActionSpec extends UnitSpec with WithFakeApplication w
 
     "other properties have been selected and allowable losses are claimed" should {
 
-      lazy val target = setupTarget(None, Some(OtherPropertiesModel(true)), Some(AllowableLossesModel(true)))
+      lazy val target = setupTarget(None, Some(OtherPropertiesModel(true)), Some(AllowableLossesModel(true)), gainModel, summaryModel, chargeableGainModel)
       lazy val result = target.lossesBroughtForward(fakeRequestWithSession)
       lazy val doc = Jsoup.parse(bodyOf(result))
 
@@ -146,9 +162,40 @@ class LossesBroughtForwardActionSpec extends UnitSpec with WithFakeApplication w
   }
 
   "Calling .submitLossesBroughtForward from the DeductionsController" when {
-    "a valid form 'No' and no other properties are claimed" should {
 
-      lazy val target = setupTarget(Some(LossesBroughtForwardModel(false)), Some(OtherPropertiesModel(false)), None)
+    "a valid form 'No' and no other properties are claimed and chargeable gain is £1000" should {
+
+      lazy val target = setupTarget(Some(LossesBroughtForwardModel(false)), Some(OtherPropertiesModel(false)), None, gainModel, summaryModel, ChargeableGainResultModel(1000, 1000, 0, 0))
+      lazy val request = fakeRequestToPOSTWithSession(("option", "No"))
+      lazy val result = target.submitLossesBroughtForward(request)
+
+      "return a 303" in {
+        status(result) shouldBe 303
+      }
+
+      "redirect to the current income page" in {
+        redirectLocation(result) shouldBe Some("/calculate-your-capital-gains/resident/current-income")
+      }
+    }
+
+    "a valid form 'No' and no other properties are claimed and chargeable gain is zero" should {
+
+      lazy val target = setupTarget(Some(LossesBroughtForwardModel(false)), Some(OtherPropertiesModel(false)), None, gainModel, summaryModel, ChargeableGainResultModel(1000, 0, 0, 1000))
+      lazy val request = fakeRequestToPOSTWithSession(("option", "No"))
+      lazy val result = target.submitLossesBroughtForward(request)
+
+      "return a 303" in {
+        status(result) shouldBe 303
+      }
+
+      "redirect to the summary page" in {
+        redirectLocation(result) shouldBe Some("/calculate-your-capital-gains/resident/summary")
+      }
+    }
+
+    "a valid form 'No' and no other properties are claimed and chargeable gain is -£1000" should {
+
+      lazy val target = setupTarget(Some(LossesBroughtForwardModel(false)), Some(OtherPropertiesModel(false)), None, gainModel, summaryModel, ChargeableGainResultModel(1000, -1000, 0, 2000))
       lazy val request = fakeRequestToPOSTWithSession(("option", "No"))
       lazy val result = target.submitLossesBroughtForward(request)
 
@@ -163,7 +210,7 @@ class LossesBroughtForwardActionSpec extends UnitSpec with WithFakeApplication w
 
     "a valid form 'No' is and other properties are claimed" should {
 
-      lazy val target = setupTarget(Some(LossesBroughtForwardModel(false)), Some(OtherPropertiesModel(true)), None)
+      lazy val target = setupTarget(Some(LossesBroughtForwardModel(false)), Some(OtherPropertiesModel(true)), None, gainModel, summaryModel, ChargeableGainResultModel(0, 0, 0, 0))
       lazy val request = fakeRequestToPOSTWithSession(("option", "No"))
       lazy val result = target.submitLossesBroughtForward(request)
 
@@ -178,7 +225,7 @@ class LossesBroughtForwardActionSpec extends UnitSpec with WithFakeApplication w
 
     "a valid form 'Yes' is and other properties are not claimed" should {
 
-      lazy val target = setupTarget(Some(LossesBroughtForwardModel(true)), Some(OtherPropertiesModel(false)), None)
+      lazy val target = setupTarget(Some(LossesBroughtForwardModel(true)), Some(OtherPropertiesModel(false)), None, gainModel, summaryModel, ChargeableGainResultModel(0, 0, 0, 0))
       lazy val request = fakeRequestToPOSTWithSession(("option", "Yes"))
       lazy val result = target.submitLossesBroughtForward(request)
 
@@ -193,7 +240,7 @@ class LossesBroughtForwardActionSpec extends UnitSpec with WithFakeApplication w
 
     "a valid form 'Yes' is and other properties are claimed" should {
 
-      lazy val target = setupTarget(Some(LossesBroughtForwardModel(true)), Some(OtherPropertiesModel(true)), None)
+      lazy val target = setupTarget(Some(LossesBroughtForwardModel(true)), Some(OtherPropertiesModel(true)), None, gainModel, summaryModel, ChargeableGainResultModel(0, 0, 0, 0))
       lazy val request = fakeRequestToPOSTWithSession(("option", "Yes"))
       lazy val result = target.submitLossesBroughtForward(request)
 
@@ -208,7 +255,7 @@ class LossesBroughtForwardActionSpec extends UnitSpec with WithFakeApplication w
 
     "an invalid form is submitted" should {
 
-      lazy val target = setupTarget(Some(LossesBroughtForwardModel(true)), Some(OtherPropertiesModel(false)), None)
+      lazy val target = setupTarget(Some(LossesBroughtForwardModel(true)), Some(OtherPropertiesModel(false)), None, gainModel, summaryModel, chargeableGainModel)
       lazy val request = fakeRequestToPOSTWithSession(("option", ""))
       lazy val result = target.submitLossesBroughtForward(request)
 

--- a/test/controllers/resident/DeductionsControllerTests/LossesBroughtForwardActionSpec.scala
+++ b/test/controllers/resident/DeductionsControllerTests/LossesBroughtForwardActionSpec.scala
@@ -193,7 +193,7 @@ class LossesBroughtForwardActionSpec extends UnitSpec with WithFakeApplication w
       }
     }
 
-    "a valid form 'No' and no other properties are claimed and chargeable gain is -£1000" should {
+    "a valid form 'No' and no other properties are claimed and has a positive chargeable gain of £1,000" should {
 
       lazy val target = setupTarget(Some(LossesBroughtForwardModel(false)), Some(OtherPropertiesModel(false)), None, gainModel, summaryModel, ChargeableGainResultModel(1000, -1000, 0, 2000))
       lazy val request = fakeRequestToPOSTWithSession(("option", "No"))

--- a/test/controllers/resident/DeductionsControllerTests/LossesBroughtForwardValueActionSpec.scala
+++ b/test/controllers/resident/DeductionsControllerTests/LossesBroughtForwardValueActionSpec.scala
@@ -20,14 +20,15 @@ import assets.MessageLookup.{lossesBroughtForwardValue => messages}
 import connectors.CalculatorConnector
 import controllers.helpers.FakeRequestHelper
 import controllers.resident.DeductionsController
-import models.resident.OtherPropertiesModel
-import models.resident.LossesBroughtForwardValueModel
+import models.resident._
 import org.jsoup.Jsoup
 import org.mockito.Matchers
 import org.scalatest.mock.MockitoSugar
 import org.mockito.Mockito._
 import play.api.test.Helpers._
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+
+import scala.concurrent.Future
 
 class LossesBroughtForwardValueActionSpec extends UnitSpec with WithFakeApplication with FakeRequestHelper with MockitoSugar{
 
@@ -94,12 +95,28 @@ class LossesBroughtForwardValueActionSpec extends UnitSpec with WithFakeApplicat
 
   "Calling .submitLossesBroughtForwardValue from the resident DeductionsController" when {
 
-    def setPostTarget(otherPropertiesModel: Option[OtherPropertiesModel]): DeductionsController = {
+    val gainModel = mock[YourAnswersSummaryModel]
+    val summaryModel = mock[ChargeableGainAnswers]
+    val chargeableGainModel = mock[ChargeableGainResultModel]
+
+    def setPostTarget(otherPropertiesModel: Option[OtherPropertiesModel],
+                      gainAnswers: YourAnswersSummaryModel,
+                      chargeableGainAnswers: ChargeableGainAnswers,
+                      chargeableGain: ChargeableGainResultModel): DeductionsController = {
 
       val mockCalcConnector = mock[CalculatorConnector]
 
       when(mockCalcConnector.fetchAndGetFormData[OtherPropertiesModel](Matchers.anyString())(Matchers.any(), Matchers.any()))
         .thenReturn(otherPropertiesModel)
+
+      when(mockCalcConnector.getYourAnswers(Matchers.any()))
+        .thenReturn(Future.successful(gainAnswers))
+
+      when(mockCalcConnector.getChargeableGainAnswers(Matchers.any()))
+        .thenReturn(Future.successful(chargeableGainAnswers))
+
+      when(mockCalcConnector.calculateRttChargeableGain(Matchers.any(), Matchers.any(), Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Some(chargeableGain)))
 
       new DeductionsController {
         override val calcConnector = mockCalcConnector
@@ -109,7 +126,7 @@ class LossesBroughtForwardValueActionSpec extends UnitSpec with WithFakeApplicat
     "given a valid form" when {
 
       "the user has disposed of other properties" should {
-        lazy val target = setPostTarget(Some(OtherPropertiesModel(true)))
+        lazy val target = setPostTarget(Some(OtherPropertiesModel(true)), gainModel, summaryModel, ChargeableGainResultModel(0, 0, 0, 0))
         lazy val request = fakeRequestToPOSTWithSession(("amount", "1000"))
         lazy val result = target.submitLossesBroughtForwardValue(request)
 
@@ -122,8 +139,8 @@ class LossesBroughtForwardValueActionSpec extends UnitSpec with WithFakeApplicat
         }
       }
 
-      "the user has not disposed of other properties" should {
-        lazy val target = setPostTarget(Some(OtherPropertiesModel(false)))
+      "the user has not disposed of other properties and has zero chargeable gain" should {
+        lazy val target = setPostTarget(Some(OtherPropertiesModel(false)), gainModel, summaryModel, ChargeableGainResultModel(2000, 0, 0, 2000))
         lazy val request = fakeRequestToPOSTWithSession(("amount", "1000"))
         lazy val result = target.submitLossesBroughtForwardValue(request)
 
@@ -133,6 +150,34 @@ class LossesBroughtForwardValueActionSpec extends UnitSpec with WithFakeApplicat
 
         s"redirect to '${controllers.resident.routes.SummaryController.summary().toString}'" in {
           redirectLocation(result).get shouldBe controllers.resident.routes.SummaryController.summary().toString
+        }
+      }
+
+      "the user has not disposed of other properties and has negative chargeable gain" should {
+        lazy val target = setPostTarget(Some(OtherPropertiesModel(false)), gainModel, summaryModel, ChargeableGainResultModel(2000, -1000, 0, 3000))
+        lazy val request = fakeRequestToPOSTWithSession(("amount", "1000"))
+        lazy val result = target.submitLossesBroughtForwardValue(request)
+
+        "return a status of 303" in {
+          status(result) shouldBe 303
+        }
+
+        s"redirect to '${controllers.resident.routes.SummaryController.summary().toString}'" in {
+          redirectLocation(result).get shouldBe controllers.resident.routes.SummaryController.summary().toString
+        }
+      }
+
+      "the user has not disposed of other properties and has positive chargeable gain of £1,000" should {
+        lazy val target = setPostTarget(Some(OtherPropertiesModel(false)), gainModel, summaryModel, ChargeableGainResultModel(1000, 1000, 0, 0))
+        lazy val request = fakeRequestToPOSTWithSession(("amount", "1000"))
+        lazy val result = target.submitLossesBroughtForwardValue(request)
+
+        "return a status of 303" in {
+          status(result) shouldBe 303
+        }
+
+        s"redirect to '${controllers.resident.routes.SummaryController.summary().toString}'" in {
+          redirectLocation(result).get shouldBe controllers.resident.routes.IncomeController.currentIncome().toString
         }
       }
     }

--- a/test/controllers/resident/DeductionsControllerTests/LossesBroughtForwardValueActionSpec.scala
+++ b/test/controllers/resident/DeductionsControllerTests/LossesBroughtForwardValueActionSpec.scala
@@ -97,7 +97,6 @@ class LossesBroughtForwardValueActionSpec extends UnitSpec with WithFakeApplicat
 
     val gainModel = mock[YourAnswersSummaryModel]
     val summaryModel = mock[ChargeableGainAnswers]
-    val chargeableGainModel = mock[ChargeableGainResultModel]
 
     def setPostTarget(otherPropertiesModel: Option[OtherPropertiesModel],
                       gainAnswers: YourAnswersSummaryModel,


### PR DESCRIPTION
Updated so:
- negative and zero chargeable gain routes to summary
- entry of zero on AEA page and a positive chargeable gain routes to previous-taxable-gains
- other positive gains route to current-income unless other screens before are required
- also added spacing in AEA action spec as it was hard to read before