### PR TITLE
Added AEA remaining to deductions and final summary

### DIFF
--- a/app/models/resident/ChargeableGainResultModel.scala
+++ b/app/models/resident/ChargeableGainResultModel.scala
@@ -22,6 +22,7 @@ case class ChargeableGainResultModel (
                                        gain: BigDecimal,
                                        chargeableGain: BigDecimal,
                                        aeaUsed: BigDecimal,
+                                       aeaRemaining: BigDecimal,
                                        deductions: BigDecimal
                                      )
 

--- a/app/views/calculation/resident/deductionsSummary.scala.html
+++ b/app/views/calculation/resident/deductionsSummary.scala.html
@@ -34,6 +34,7 @@ articleLayout = false
     )))
     @summaryNumericRowHelper("chargeableGain", if(result.chargeableGain < 0) {
     Messages("calc.resident.summary.chargeableLoss")} else {Messages("calc.resident.summary.chargeableGain")}, result.chargeableGain)
+    @summaryNumericRowHelper("aeaRemaining", Messages("calc.resident.summary.aeaRemaining"), result.aeaRemaining)
 </section>
 
 <!-- Your Answers Section -->

--- a/app/views/calculation/resident/summary/finalSummary.scala.html
+++ b/app/views/calculation/resident/summary/finalSummary.scala.html
@@ -42,6 +42,7 @@ articleLayout = false
     } else {
         @summaryGainAndRateHelper("gainAndRate", Messages("calc.resident.summary.taxRate"), result.firstBand, result.firstRate, result.secondBand, result.secondRate)
     }
+    @summaryNumericRowHelper("aeaRemaining", Messages("calc.resident.summary.aeaRemaining"), 0)
 </section>
 
 <!-- Your Answers Section -->

--- a/conf/messages
+++ b/conf/messages
@@ -353,6 +353,7 @@ calc.resident.summary.totalLoss = Loss
 calc.resident.summary.reliefs = Reliefs
 calc.resident.summary.allowableLosses = Allowable losses
 calc.resident.summary.aeaUsed = Capital gains tax allowance used
+calc.resident.summary.aeaRemaining = Capital gains tax allowance left
 calc.resident.summary.broughtForwardLoss = Loss brought forward
 calc.resident.summary.deductions = Deductions
 calc.resident.summary.chargeableLoss = Carried forward loss

--- a/test/assets/MessageLookup.scala
+++ b/test/assets/MessageLookup.scala
@@ -119,6 +119,7 @@ object MessageLookup {
     val chargeableLoss = "Carried forward loss"
     val chargeableGain = "Taxable gain"
     val taxRate = "Tax Rate"
+    val aeaRemaining = "Capital gains tax allowance left"
   }
 
   //Reliefs messages

--- a/test/controllers/resident/DeductionsControllerTests/AnnualExemptAmountActionSpec.scala
+++ b/test/controllers/resident/DeductionsControllerTests/AnnualExemptAmountActionSpec.scala
@@ -121,7 +121,7 @@ class AnnualExemptAmountActionSpec extends UnitSpec with WithFakeApplication wit
   "Calling .submitAnnualExemptAmount from the DeductionsController" when {
 
     "a valid form is submitted with AEA of 1000 and zero taxable gain" should {
-      lazy val target = setupTarget(Some(AnnualExemptAmountModel(1000)), gainModel, summaryModel, ChargeableGainResultModel(2000, 0, 1000, 1000))
+      lazy val target = setupTarget(Some(AnnualExemptAmountModel(1000)), gainModel, summaryModel, ChargeableGainResultModel(2000, 0, 1000, 0, 1000))
       lazy val request = fakeRequestToPOSTWithSession(("amount", "1000"))
       lazy val result = target.submitAnnualExemptAmount(request)
 
@@ -135,7 +135,7 @@ class AnnualExemptAmountActionSpec extends UnitSpec with WithFakeApplication wit
     }
 
     "a valid form is submitted with AEA of 0 and positive taxable gain" should {
-      lazy val target = setupTarget(Some(AnnualExemptAmountModel(0)), gainModel, summaryModel, ChargeableGainResultModel(1000, 1000, 0, 0))
+      lazy val target = setupTarget(Some(AnnualExemptAmountModel(0)), gainModel, summaryModel, ChargeableGainResultModel(1000, 1000, 0, 0, 0))
       lazy val request = fakeRequestToPOSTWithSession(("amount", "0"))
       lazy val result = target.submitAnnualExemptAmount(request)
 
@@ -149,7 +149,7 @@ class AnnualExemptAmountActionSpec extends UnitSpec with WithFakeApplication wit
     }
 
     "a valid form is submitted with AEA of 1000 and positive taxable gain" should {
-      lazy val target = setupTarget(Some(AnnualExemptAmountModel(1000)), gainModel, summaryModel, ChargeableGainResultModel(2000, 1000, 1000, 0))
+      lazy val target = setupTarget(Some(AnnualExemptAmountModel(1000)), gainModel, summaryModel, ChargeableGainResultModel(2000, 1000, 1000, 0, 0))
       lazy val request = fakeRequestToPOSTWithSession(("amount", "1000"))
       lazy val result = target.submitAnnualExemptAmount(request)
 
@@ -164,7 +164,7 @@ class AnnualExemptAmountActionSpec extends UnitSpec with WithFakeApplication wit
 
     "an invalid form is submitted" should {
 
-      lazy val target = setupTarget(None, gainModel, summaryModel, ChargeableGainResultModel(2000, 1000, 1000, 0))
+      lazy val target = setupTarget(None, gainModel, summaryModel, ChargeableGainResultModel(2000, 1000, 1000, 0, 0))
       lazy val request = fakeRequestToPOSTWithSession(("amount", ""))
       lazy val result = target.submitAnnualExemptAmount(request)
       lazy val doc = Jsoup.parse(bodyOf(result))

--- a/test/controllers/resident/DeductionsControllerTests/LossesBroughtForwardActionSpec.scala
+++ b/test/controllers/resident/DeductionsControllerTests/LossesBroughtForwardActionSpec.scala
@@ -165,7 +165,7 @@ class LossesBroughtForwardActionSpec extends UnitSpec with WithFakeApplication w
 
     "a valid form 'No' and no other properties are claimed and chargeable gain is £1000" should {
 
-      lazy val target = setupTarget(Some(LossesBroughtForwardModel(false)), Some(OtherPropertiesModel(false)), None, gainModel, summaryModel, ChargeableGainResultModel(1000, 1000, 0, 0))
+      lazy val target = setupTarget(Some(LossesBroughtForwardModel(false)), Some(OtherPropertiesModel(false)), None, gainModel, summaryModel, ChargeableGainResultModel(1000, 1000, 0, 0, 0))
       lazy val request = fakeRequestToPOSTWithSession(("option", "No"))
       lazy val result = target.submitLossesBroughtForward(request)
 
@@ -180,7 +180,7 @@ class LossesBroughtForwardActionSpec extends UnitSpec with WithFakeApplication w
 
     "a valid form 'No' and no other properties are claimed and chargeable gain is zero" should {
 
-      lazy val target = setupTarget(Some(LossesBroughtForwardModel(false)), Some(OtherPropertiesModel(false)), None, gainModel, summaryModel, ChargeableGainResultModel(1000, 0, 0, 1000))
+      lazy val target = setupTarget(Some(LossesBroughtForwardModel(false)), Some(OtherPropertiesModel(false)), None, gainModel, summaryModel, ChargeableGainResultModel(1000, 0, 0, 0, 1000))
       lazy val request = fakeRequestToPOSTWithSession(("option", "No"))
       lazy val result = target.submitLossesBroughtForward(request)
 
@@ -195,7 +195,7 @@ class LossesBroughtForwardActionSpec extends UnitSpec with WithFakeApplication w
 
     "a valid form 'No' and no other properties are claimed and has a positive chargeable gain of £1,000" should {
 
-      lazy val target = setupTarget(Some(LossesBroughtForwardModel(false)), Some(OtherPropertiesModel(false)), None, gainModel, summaryModel, ChargeableGainResultModel(1000, -1000, 0, 2000))
+      lazy val target = setupTarget(Some(LossesBroughtForwardModel(false)), Some(OtherPropertiesModel(false)), None, gainModel, summaryModel, ChargeableGainResultModel(1000, -1000, 0, 0, 2000))
       lazy val request = fakeRequestToPOSTWithSession(("option", "No"))
       lazy val result = target.submitLossesBroughtForward(request)
 
@@ -210,7 +210,7 @@ class LossesBroughtForwardActionSpec extends UnitSpec with WithFakeApplication w
 
     "a valid form 'No' is and other properties are claimed" should {
 
-      lazy val target = setupTarget(Some(LossesBroughtForwardModel(false)), Some(OtherPropertiesModel(true)), None, gainModel, summaryModel, ChargeableGainResultModel(0, 0, 0, 0))
+      lazy val target = setupTarget(Some(LossesBroughtForwardModel(false)), Some(OtherPropertiesModel(true)), None, gainModel, summaryModel, ChargeableGainResultModel(0, 0, 0, 0, 0))
       lazy val request = fakeRequestToPOSTWithSession(("option", "No"))
       lazy val result = target.submitLossesBroughtForward(request)
 
@@ -225,7 +225,7 @@ class LossesBroughtForwardActionSpec extends UnitSpec with WithFakeApplication w
 
     "a valid form 'Yes' is and other properties are not claimed" should {
 
-      lazy val target = setupTarget(Some(LossesBroughtForwardModel(true)), Some(OtherPropertiesModel(false)), None, gainModel, summaryModel, ChargeableGainResultModel(0, 0, 0, 0))
+      lazy val target = setupTarget(Some(LossesBroughtForwardModel(true)), Some(OtherPropertiesModel(false)), None, gainModel, summaryModel, ChargeableGainResultModel(0, 0, 0, 0, 0))
       lazy val request = fakeRequestToPOSTWithSession(("option", "Yes"))
       lazy val result = target.submitLossesBroughtForward(request)
 
@@ -240,7 +240,7 @@ class LossesBroughtForwardActionSpec extends UnitSpec with WithFakeApplication w
 
     "a valid form 'Yes' is and other properties are claimed" should {
 
-      lazy val target = setupTarget(Some(LossesBroughtForwardModel(true)), Some(OtherPropertiesModel(true)), None, gainModel, summaryModel, ChargeableGainResultModel(0, 0, 0, 0))
+      lazy val target = setupTarget(Some(LossesBroughtForwardModel(true)), Some(OtherPropertiesModel(true)), None, gainModel, summaryModel, ChargeableGainResultModel(0, 0, 0, 0, 0))
       lazy val request = fakeRequestToPOSTWithSession(("option", "Yes"))
       lazy val result = target.submitLossesBroughtForward(request)
 

--- a/test/controllers/resident/DeductionsControllerTests/LossesBroughtForwardValueActionSpec.scala
+++ b/test/controllers/resident/DeductionsControllerTests/LossesBroughtForwardValueActionSpec.scala
@@ -125,7 +125,7 @@ class LossesBroughtForwardValueActionSpec extends UnitSpec with WithFakeApplicat
     "given a valid form" when {
 
       "the user has disposed of other properties" should {
-        lazy val target = setPostTarget(Some(OtherPropertiesModel(true)), gainModel, summaryModel, ChargeableGainResultModel(0, 0, 0, 0))
+        lazy val target = setPostTarget(Some(OtherPropertiesModel(true)), gainModel, summaryModel, ChargeableGainResultModel(0, 0, 0, 0, 0))
         lazy val request = fakeRequestToPOSTWithSession(("amount", "1000"))
         lazy val result = target.submitLossesBroughtForwardValue(request)
 
@@ -139,7 +139,7 @@ class LossesBroughtForwardValueActionSpec extends UnitSpec with WithFakeApplicat
       }
 
       "the user has not disposed of other properties and has zero chargeable gain" should {
-        lazy val target = setPostTarget(Some(OtherPropertiesModel(false)), gainModel, summaryModel, ChargeableGainResultModel(2000, 0, 0, 2000))
+        lazy val target = setPostTarget(Some(OtherPropertiesModel(false)), gainModel, summaryModel, ChargeableGainResultModel(2000, 0, 0, 0, 2000))
         lazy val request = fakeRequestToPOSTWithSession(("amount", "1000"))
         lazy val result = target.submitLossesBroughtForwardValue(request)
 
@@ -153,7 +153,7 @@ class LossesBroughtForwardValueActionSpec extends UnitSpec with WithFakeApplicat
       }
 
       "the user has not disposed of other properties and has negative chargeable gain" should {
-        lazy val target = setPostTarget(Some(OtherPropertiesModel(false)), gainModel, summaryModel, ChargeableGainResultModel(2000, -1000, 0, 3000))
+        lazy val target = setPostTarget(Some(OtherPropertiesModel(false)), gainModel, summaryModel, ChargeableGainResultModel(2000, -1000, 0, 0, 3000))
         lazy val request = fakeRequestToPOSTWithSession(("amount", "1000"))
         lazy val result = target.submitLossesBroughtForwardValue(request)
 
@@ -167,7 +167,7 @@ class LossesBroughtForwardValueActionSpec extends UnitSpec with WithFakeApplicat
       }
 
       "the user has not disposed of other properties and has positive chargeable gain of £1,000" should {
-        lazy val target = setPostTarget(Some(OtherPropertiesModel(false)), gainModel, summaryModel, ChargeableGainResultModel(1000, 1000, 0, 0))
+        lazy val target = setPostTarget(Some(OtherPropertiesModel(false)), gainModel, summaryModel, ChargeableGainResultModel(1000, 1000, 0, 0, 0))
         lazy val request = fakeRequestToPOSTWithSession(("amount", "1000"))
         lazy val result = target.submitLossesBroughtForwardValue(request)
 
@@ -182,7 +182,7 @@ class LossesBroughtForwardValueActionSpec extends UnitSpec with WithFakeApplicat
     }
 
     "given an invalid form" should {
-      lazy val target = setPostTarget(Some(OtherPropertiesModel(false)), gainModel, summaryModel, ChargeableGainResultModel(1000, 1000, 0, 0))
+      lazy val target = setPostTarget(Some(OtherPropertiesModel(false)), gainModel, summaryModel, ChargeableGainResultModel(1000, 1000, 0, 0, 0))
       lazy val request = fakeRequestToPOSTWithSession(("amount", ""))
       lazy val result = target.submitLossesBroughtForwardValue(request)
 

--- a/test/controllers/resident/SummaryActionSpec.scala
+++ b/test/controllers/resident/SummaryActionSpec.scala
@@ -118,7 +118,7 @@ class SummaryActionSpec extends UnitSpec with WithFakeApplication with FakeReque
         0)
       lazy val chargeableGainAnswers = ChargeableGainAnswers(Some(ReliefsModel(false)), None, Some(OtherPropertiesModel(false)),
         None, None, Some(LossesBroughtForwardModel(false)), None, None)
-      lazy val chargeableGainResultModel = ChargeableGainResultModel(10000, -1100, 11100, 11100)
+      lazy val chargeableGainResultModel = ChargeableGainResultModel(10000, -1100, 11100, 0, 11100)
       lazy val incomeAnswersModel = IncomeAnswersModel(None, None, None)
       lazy val target = setupTarget(
         yourAnswersSummaryModel,
@@ -156,7 +156,7 @@ class SummaryActionSpec extends UnitSpec with WithFakeApplication with FakeReque
         0)
       lazy val chargeableGainAnswers = ChargeableGainAnswers(Some(ReliefsModel(false)), None, Some(OtherPropertiesModel(false)),
         None, None, Some(LossesBroughtForwardModel(true)), Some(LossesBroughtForwardValueModel(1000)), None)
-      lazy val chargeableGainResultModel = ChargeableGainResultModel(10000, -1100, 11100, 11100)
+      lazy val chargeableGainResultModel = ChargeableGainResultModel(10000, -1100, 11100, 0, 11100)
       lazy val incomeAnswersModel = IncomeAnswersModel(None, None, None)
       lazy val target = setupTarget(
         yourAnswersSummaryModel,
@@ -194,7 +194,7 @@ class SummaryActionSpec extends UnitSpec with WithFakeApplication with FakeReque
         0)
       lazy val chargeableGainAnswers = ChargeableGainAnswers(Some(ReliefsModel(false)), None, Some(OtherPropertiesModel(true)),
         Some(AllowableLossesModel(false)), None, Some(LossesBroughtForwardModel(false)), None, Some(AnnualExemptAmountModel(10000)))
-      lazy val chargeableGainResultModel = ChargeableGainResultModel(10000, -1100, 11100, 11100)
+      lazy val chargeableGainResultModel = ChargeableGainResultModel(10000, -1100, 11100, 0, 11100)
       lazy val incomeAnswersModel = IncomeAnswersModel(None, None, None)
       lazy val target = setupTarget(
         yourAnswersSummaryModel,
@@ -232,7 +232,7 @@ class SummaryActionSpec extends UnitSpec with WithFakeApplication with FakeReque
         0)
       lazy val chargeableGainAnswers = ChargeableGainAnswers(Some(ReliefsModel(false)), None, Some(OtherPropertiesModel(false)),
         Some(AllowableLossesModel(false)), None, Some(LossesBroughtForwardModel(false)), None, None)
-      lazy val chargeableGainResultModel = ChargeableGainResultModel(20000, 20000, 11100, 11100)
+      lazy val chargeableGainResultModel = ChargeableGainResultModel(20000, 20000, 11100, 0, 11100)
       lazy val incomeAnswersModel = IncomeAnswersModel(None, Some(CurrentIncomeModel(20000)), Some(PersonalAllowanceModel(10000)))
       lazy val totalGainAndTaxOwedModel = TotalGainAndTaxOwedModel(20000, 20000, 11100, 11100, 3600, 20000, 18, None, None)
       lazy val target = setupTarget(

--- a/test/views/resident/DeductionsSummaryViewSpec.scala
+++ b/test/views/resident/DeductionsSummaryViewSpec.scala
@@ -46,6 +46,7 @@ class DeductionsSummaryViewSpec extends UnitSpec with WithFakeApplication with F
     lazy val results = ChargeableGainResultModel(BigDecimal(50000),
       BigDecimal(38900),
       BigDecimal(11100),
+      BigDecimal(0),
       BigDecimal(11100))
     lazy val backLink = "/calculate-your-capital-gains/resident/losses-brought-forward"
     
@@ -147,7 +148,6 @@ class DeductionsSummaryViewSpec extends UnitSpec with WithFakeApplication with F
             doc.select("#deductions-amount").text should include("Loss brought forward £0")
           }
         }
-
       }
 
       "has a numeric output row for the chargeable gain" which {
@@ -161,6 +161,16 @@ class DeductionsSummaryViewSpec extends UnitSpec with WithFakeApplication with F
         }
       }
 
+      "has a numeric output row for the AEA remaining" which {
+
+        "should have the question text 'Capital gains tax allowance left" in {
+          doc.select("#aeaRemaining-question").text should include(messages.aeaRemaining)
+        }
+
+        "include a value for Capital gains tax allowance left of £0" in {
+          doc.select("#aeaRemaining-amount").text should include("£0")
+        }
+      }
     }
 
     s"have a section for Your answers" which {
@@ -341,6 +351,7 @@ class DeductionsSummaryViewSpec extends UnitSpec with WithFakeApplication with F
     lazy val results = ChargeableGainResultModel(BigDecimal(50000),
       BigDecimal(-11000),
       BigDecimal(0),
+      BigDecimal(11000),
       BigDecimal(71000))
 
     lazy val backLink = "/calculate-your-capital-gains/resident/annual-exempt-amount"

--- a/test/views/resident/summary/FinalSummaryViewSpec.scala
+++ b/test/views/resident/summary/FinalSummaryViewSpec.scala
@@ -186,6 +186,17 @@ class FinalSummaryViewSpec extends UnitSpec with WithFakeApplication with FakeRe
           doc.select("#firstBand").text should include("18%")
         }
       }
+
+      "has a numeric output row for the AEA remaining" which {
+
+        "should have the question text 'Capital gains tax allowance left" in {
+          doc.select("#aeaRemaining-question").text should include(messages.aeaRemaining)
+        }
+
+        "include a value for Capital gains tax allowance left of £0" in {
+          doc.select("#aeaRemaining-amount").text should include("£0")
+        }
+      }
     }
 
     s"have a section for Your answers" which {


### PR DESCRIPTION
**Merge after CGT-1453 (backend)**

Final summary does not use backend to populate AEA remaining as this will always be £0 (if there was any left they must have had a negative or zero chargeable gain therefore be kicked out at deductions summary)
