### PR TITLE
CGT-1485: Session Timeout now dynamic based on user journey

### DIFF
--- a/app/controllers/TimeoutController.scala
+++ b/app/controllers/TimeoutController.scala
@@ -16,20 +16,16 @@
 
 package controllers
 
-import java.util.UUID
 import views.html.warnings._
 import play.api.mvc.{AnyContent, Action}
 import uk.gov.hmrc.play.frontend.controller.FrontendController
-import uk.gov.hmrc.play.http.{SessionKeys, HeaderCarrier}
-import scala.concurrent.{Future}
-
 import scala.concurrent.Future
 
 object TimeoutController extends TimeoutController
 
 trait TimeoutController extends FrontendController {
 
-  def timeout:Action[AnyContent] = Action.async { implicit request =>
-    Future.successful(Ok(sessionTimeout()))
+  def timeout(restartUrl: String) : Action[AnyContent] = Action.async { implicit request =>
+    Future.successful(Ok(sessionTimeout(restartUrl)))
   }
 }

--- a/app/controllers/nonresident/CalculationController.scala
+++ b/app/controllers/nonresident/CalculationController.scala
@@ -53,6 +53,7 @@ import models.nonresident._
 
 trait CalculationController extends FrontendController with ValidActiveSession {
 
+  override val sessionTimeoutUrl = controllers.nonresident.routes.CalculationController.restart().url
   val calcConnector: CalculatorConnector
   val calcElectionConstructor: CalculationElectionConstructor
 

--- a/app/controllers/predicates/FeatureLock.scala
+++ b/app/controllers/predicates/FeatureLock.scala
@@ -17,42 +17,41 @@
 package controllers.predicates
 
 import config.ApplicationConfig
-import controllers.routes
 import play.api.mvc.{Action, Result, AnyContent, Request}
 
 import scala.concurrent.Future
 
 trait FeatureLock extends ValidActiveSession {
 
+  val featureEnabled: Boolean = false
   private type PlayRequest = Request[AnyContent] => Result
   private type AsyncPlayRequest = Request[AnyContent] => Future[Result]
 
-  class FeatureLockFor(condition: Boolean) {
-
-    def async(action: AsyncPlayRequest): Action[AnyContent] = {
-      ValidateSession.async { implicit request =>
-        if (condition) {
-          action(request)
-        }
-        else {
-          Future.successful(NotFound)
-        }
+  def async(action: AsyncPlayRequest): Action[AnyContent] = {
+    ValidateSession.async { implicit request =>
+      if (featureEnabled) {
+        action(request)
       }
-    }
-
-    def asyncNoTimeout(action: AsyncPlayRequest): Action[AnyContent] = {
-      Action.async { implicit request =>
-        if (condition) {
-          action(request)
-        }
-        else {
-          Future.successful(NotFound)
-        }
+      else {
+        Future.successful(NotFound)
       }
     }
   }
 
-  object FeatureLockForRTT extends FeatureLockFor(RTTCondition)
+  def asyncNoTimeout(action: AsyncPlayRequest): Action[AnyContent] = {
+    Action.async { implicit request =>
+      if (featureEnabled) {
+        action(request)
+      }
+      else {
+        Future.successful(NotFound)
+      }
+    }
+  }
 
-  lazy val RTTCondition = ApplicationConfig.featureRTTEnabled
+  object FeatureLockForRTT extends FeatureLock {
+    lazy val RTTEnabled = ApplicationConfig.featureRTTEnabled
+    override val featureEnabled = RTTEnabled
+    override val sessionTimeoutUrl = controllers.resident.routes.GainController.disposalDate().url
+  }
 }

--- a/app/controllers/predicates/FeatureLock.scala
+++ b/app/controllers/predicates/FeatureLock.scala
@@ -50,8 +50,7 @@ trait FeatureLock extends ValidActiveSession {
   }
 
   object FeatureLockForRTT extends FeatureLock {
-    lazy val RTTEnabled = ApplicationConfig.featureRTTEnabled
-    override val featureEnabled = RTTEnabled
+    override val featureEnabled = ApplicationConfig.featureRTTEnabled
     override val sessionTimeoutUrl = controllers.resident.routes.GainController.disposalDate().url
   }
 }

--- a/app/controllers/predicates/ValidActiveSession.scala
+++ b/app/controllers/predicates/ValidActiveSession.scala
@@ -25,6 +25,8 @@ import scala.concurrent.Future
 
 trait ValidActiveSession extends FrontendController {
 
+  val sessionTimeoutUrl: String = ""
+
   private type PlayRequest = Request[AnyContent] => Result
   private type AsyncRequest = Request[AnyContent] => Future[Result]
 
@@ -33,7 +35,7 @@ trait ValidActiveSession extends FrontendController {
     def async(action: AsyncRequest): Action[AnyContent] = {
       Action.async { implicit request =>
         if (request.session.get(SessionKeys.sessionId).isEmpty) {
-          Future.successful(Redirect(routes.TimeoutController.timeout()))
+          Future.successful(Redirect(routes.TimeoutController.timeout(sessionTimeoutUrl)))
         } else {
           action(request)
         }

--- a/app/views/warnings/sessionTimeout.scala.html
+++ b/app/views/warnings/sessionTimeout.scala.html
@@ -1,11 +1,11 @@
 @import views.html.helpers._
 
-@()(implicit request: Request[_])
+@(restartUrl: String)(implicit request: Request[_])
 
 @main_template(Messages("session.timeout.message")) {
 
     <h1 class="heading-large">@Messages("session.timeout.message")</h1>
 
-    <a id="startAgain" class="bold-medium" href="@controllers.nonresident.routes.CalculationController.restart" data-journey-click="nav:calc:restart">@Messages("calc.summary.startAgain")</a>
+    <a id="startAgain" class="bold-medium" href="@restartUrl" data-journey-click="nav:calc:restart">@Messages("calc.summary.startAgain")</a>
 
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,2 +1,12 @@
 # microservice specific routes
 
+#Assets routes
+GET         /assets/*file           controllers.Assets.at(path="/public", file)
+
+#Feedback routes
+GET         /feedback               controllers.FeedbackController.show
+POST        /feedback               controllers.FeedbackController.submit
+GET         /thankyou               controllers.FeedbackController.thankyou
+
+#Session Timeout route
+GET         /session-timeout        controllers.TimeoutController.timeout(restartUrl: String)

--- a/conf/nr.routes
+++ b/conf/nr.routes
@@ -1,90 +1,88 @@
 #Non Resident Calculation controller routes
 ########################################################
 
-GET         /assets/*file            controllers.Assets.at(path="/public", file)
-
 #Customer Type
-GET         /                        controllers.nonresident.CalculationController.customerType
-GET         /customer-type           controllers.nonresident.CalculationController.customerType
-POST        /customer-type           controllers.nonresident.CalculationController.submitCustomerType
+GET         /                                   controllers.nonresident.CalculationController.customerType
+GET         /customer-type                      controllers.nonresident.CalculationController.customerType
+POST        /customer-type                      controllers.nonresident.CalculationController.submitCustomerType
 
 #Disabled Trustee
-GET         /disabled-trustee        controllers.nonresident.CalculationController.disabledTrustee
-POST        /disabled-trustee        controllers.nonresident.CalculationController.submitDisabledTrustee
+GET         /disabled-trustee                   controllers.nonresident.CalculationController.disabledTrustee
+POST        /disabled-trustee                   controllers.nonresident.CalculationController.submitDisabledTrustee
 
 #Current Income
-GET         /current-income          controllers.nonresident.CalculationController.currentIncome
-POST        /current-income          controllers.nonresident.CalculationController.submitCurrentIncome
+GET         /current-income                     controllers.nonresident.CalculationController.currentIncome
+POST        /current-income                     controllers.nonresident.CalculationController.submitCurrentIncome
 
 #Personal Allowance
-GET         /personal-allowance      controllers.nonresident.CalculationController.personalAllowance
-POST        /personal-allowance      controllers.nonresident.CalculationController.submitPersonalAllowance
+GET         /personal-allowance                 controllers.nonresident.CalculationController.personalAllowance
+POST        /personal-allowance                 controllers.nonresident.CalculationController.submitPersonalAllowance
 
 #Other Properties
-GET         /other-properties        controllers.nonresident.CalculationController.otherProperties
-POST        /other-properties        controllers.nonresident.CalculationController.submitOtherProperties
+GET         /other-properties                   controllers.nonresident.CalculationController.otherProperties
+POST        /other-properties                   controllers.nonresident.CalculationController.submitOtherProperties
 
 #Allowance
-GET         /allowance               controllers.nonresident.CalculationController.annualExemptAmount
-POST        /allowance               controllers.nonresident.CalculationController.submitAnnualExemptAmount
+GET         /allowance                          controllers.nonresident.CalculationController.annualExemptAmount
+POST        /allowance                          controllers.nonresident.CalculationController.submitAnnualExemptAmount
 
 #Acquisition Date
-GET         /acquisition-date        controllers.nonresident.CalculationController.acquisitionDate
-POST        /acquisition-date        controllers.nonresident.CalculationController.submitAcquisitionDate
+GET         /acquisition-date                   controllers.nonresident.CalculationController.acquisitionDate
+POST        /acquisition-date                   controllers.nonresident.CalculationController.submitAcquisitionDate
 
 #Acquisition Value
-GET         /acquisition-value       controllers.nonresident.CalculationController.acquisitionValue
-POST        /acquisition-value       controllers.nonresident.CalculationController.submitAcquisitionValue
+GET         /acquisition-value                  controllers.nonresident.CalculationController.acquisitionValue
+POST        /acquisition-value                  controllers.nonresident.CalculationController.submitAcquisitionValue
 
 #Rebased Value
-GET         /rebased-value           controllers.nonresident.CalculationController.rebasedValue
-POST        /rebased-value           controllers.nonresident.CalculationController.submitRebasedValue
+GET         /rebased-value                      controllers.nonresident.CalculationController.rebasedValue
+POST        /rebased-value                      controllers.nonresident.CalculationController.submitRebasedValue
 
 #Rebased Costs
-GET         /rebased-costs           controllers.nonresident.CalculationController.rebasedCosts
-POST        /rebased-costs           controllers.nonresident.CalculationController.submitRebasedCosts
+GET         /rebased-costs                      controllers.nonresident.CalculationController.rebasedCosts
+POST        /rebased-costs                      controllers.nonresident.CalculationController.submitRebasedCosts
 
 #Improvements
-GET         /improvements            controllers.nonresident.CalculationController.improvements
-POST        /improvements            controllers.nonresident.CalculationController.submitImprovements
+GET         /improvements                       controllers.nonresident.CalculationController.improvements
+POST        /improvements                       controllers.nonresident.CalculationController.submitImprovements
 
 #Disposal Date
-GET         /disposal-date           controllers.nonresident.CalculationController.disposalDate
-POST        /disposal-date           controllers.nonresident.CalculationController.submitDisposalDate
+GET         /disposal-date                      controllers.nonresident.CalculationController.disposalDate
+POST        /disposal-date                      controllers.nonresident.CalculationController.submitDisposalDate
 
 #No Capital Gains Tax
-GET         /no-capital-gains-tax    controllers.nonresident.CalculationController.noCapitalGainsTax
+GET         /no-capital-gains-tax               controllers.nonresident.CalculationController.noCapitalGainsTax
 
 #Disposal Value
-GET         /disposal-value          controllers.nonresident.CalculationController.disposalValue
-POST        /disposal-value          controllers.nonresident.CalculationController.submitDisposalValue
+GET         /disposal-value                     controllers.nonresident.CalculationController.disposalValue
+POST        /disposal-value                     controllers.nonresident.CalculationController.submitDisposalValue
 
 #Acquisition Costs
-GET         /acquisition-costs       controllers.nonresident.CalculationController.acquisitionCosts
-POST        /acquisition-costs       controllers.nonresident.CalculationController.submitAcquisitionCosts
+GET         /acquisition-costs                  controllers.nonresident.CalculationController.acquisitionCosts
+POST        /acquisition-costs                  controllers.nonresident.CalculationController.submitAcquisitionCosts
 
 #Disposal Costs
-GET         /disposal-costs          controllers.nonresident.CalculationController.disposalCosts
-POST        /disposal-costs          controllers.nonresident.CalculationController.submitDisposalCosts
+GET         /disposal-costs                     controllers.nonresident.CalculationController.disposalCosts
+POST        /disposal-costs                     controllers.nonresident.CalculationController.submitDisposalCosts
 
 #Private Residence Relief
-GET         /private-residence-relief controllers.nonresident.CalculationController.privateResidenceRelief
-POST        /private-residence-relief controllers.nonresident.CalculationController.submitPrivateResidenceRelief
+GET         /private-residence-relief           controllers.nonresident.CalculationController.privateResidenceRelief
+POST        /private-residence-relief           controllers.nonresident.CalculationController.submitPrivateResidenceRelief
 
 #Allowable Losses
-GET         /allowable-losses        controllers.nonresident.CalculationController.allowableLosses
-POST        /allowable-losses        controllers.nonresident.CalculationController.submitAllowableLosses
+GET         /allowable-losses                   controllers.nonresident.CalculationController.allowableLosses
+POST        /allowable-losses                   controllers.nonresident.CalculationController.submitAllowableLosses
 
 #Calculation Election
-GET         /calculation-election    controllers.nonresident.CalculationController.calculationElection
-POST        /calculation-election    controllers.nonresident.CalculationController.submitCalculationElection
+GET         /calculation-election               controllers.nonresident.CalculationController.calculationElection
+POST        /calculation-election               controllers.nonresident.CalculationController.submitCalculationElection
 
 #Other Reliefs
-GET         /other-reliefs           controllers.nonresident.CalculationController.otherReliefs
-POST        /other-reliefs           controllers.nonresident.CalculationController.submitOtherReliefs
+GET         /other-reliefs                      controllers.nonresident.CalculationController.otherReliefs
+POST        /other-reliefs                      controllers.nonresident.CalculationController.submitOtherReliefs
 
-GET         /other-reliefs-flat      controllers.nonresident.CalculationController.otherReliefsFlat
-POST        /other-reliefs-flat      controllers.nonresident.CalculationController.submitOtherReliefsFlat
+GET         /other-reliefs-flat                 controllers.nonresident.CalculationController.otherReliefsFlat
+POST        /other-reliefs-flat                 controllers.nonresident.CalculationController.submitOtherReliefsFlat
 
 GET         /other-reliefs-time-apportioned     controllers.nonresident.CalculationController.otherReliefsTA
 POST        /other-reliefs-time-apportioned     controllers.nonresident.CalculationController.submitOtherReliefsTA
@@ -96,15 +94,6 @@ POST        /other-reliefs-rebased              controllers.nonresident.Calculat
 
 #Summary screen route
 ########################################################
-GET         /summary                 controllers.nonresident.CalculationController.summary
-GET         /restart                 controllers.nonresident.CalculationController.restart
-
-#Session Timeout route
+GET         /summary                            controllers.nonresident.CalculationController.summary
+GET         /restart                            controllers.nonresident.CalculationController.restart
 ########################################################
-GET         /session-timeout         controllers.TimeoutController.timeout
-########################################################
-
-#Feedback routes
-GET         /feedback               controllers.FeedbackController.show
-POST        /feedback               controllers.FeedbackController.submit
-GET         /thankyou               controllers.FeedbackController.thankyou

--- a/test/controllers/CalculationControllerTests/CurrentIncomeSpec.scala
+++ b/test/controllers/CalculationControllerTests/CurrentIncomeSpec.scala
@@ -147,13 +147,13 @@ class CurrentIncomeSpec extends UnitSpec with WithFakeApplication with MockitoSu
     "called with no active session or valid session Id" should {
 
       lazy val fakeRequest = FakeRequest("GET", "/calculate-your-capital-gains/non-resident/current-income")
-      s"redirect to ${controllers.routes.TimeoutController.timeout()}" in {
+      s"redirect to ${controllers.routes.TimeoutController.timeout("")}" in {
 
         val target = setupTarget(None, None)
         lazy val result = target.currentIncome(fakeRequest)
         lazy val document = Jsoup.parse(bodyOf(result))
 
-        redirectLocation(result) shouldBe Some(s"${controllers.routes.TimeoutController.timeout()}")
+        redirectLocation(result).get should include ("/calculate-your-capital-gains/session-timeout")
       }
     }
   }

--- a/test/controllers/PredicateControllerSpec.scala
+++ b/test/controllers/PredicateControllerSpec.scala
@@ -27,8 +27,12 @@ import scala.concurrent.Future
 
 class PredicateControllerSpec extends UnitSpec with WithFakeApplication with FrontendController with FeatureLock {
 
-  object FeatureLockForTrue extends FeatureLockFor(true)
-  object FeatureLockForFalse extends FeatureLockFor(false)
+  object FeatureLockForTrue extends FeatureLock {
+    override val featureEnabled = true
+  }
+  object FeatureLockForFalse extends FeatureLock {
+    override val featureEnabled = false
+  }
 
   val featureLockTestTrue = FeatureLockForTrue.async { implicit request =>
     Future.successful(Ok("Hello"))

--- a/test/controllers/TimeoutControllerSpec.scala
+++ b/test/controllers/TimeoutControllerSpec.scala
@@ -37,7 +37,7 @@ class TimeoutControllerSpec extends UnitSpec with WithFakeApplication {
 
     "when called with no session" should {
 
-      object timeoutTestDataItem extends fakeRequestTo("", TimeoutController.timeout)
+      object timeoutTestDataItem extends fakeRequestTo("", TimeoutController.timeout("test"))
 
       "return a 200" in {
         status(timeoutTestDataItem.result) shouldBe 200
@@ -49,6 +49,10 @@ class TimeoutControllerSpec extends UnitSpec with WithFakeApplication {
 
       "contain the heading 'Your session has timeed out." in {
         timeoutTestDataItem.jsoupDoc.select("h1").text shouldEqual Messages("session.timeout.message")
+      }
+
+      "have a restart link to href of 'test'" in {
+        timeoutTestDataItem.jsoupDoc.getElementById("startAgain").attr("href") shouldEqual "test"
       }
     }
   }

--- a/test/controllers/resident/DeductionsControllerTests/AllowableLossesActionSpec.scala
+++ b/test/controllers/resident/DeductionsControllerTests/AllowableLossesActionSpec.scala
@@ -105,7 +105,7 @@ class AllowableLossesActionSpec extends UnitSpec with WithFakeApplication with F
       }
 
       "return you to the session timeout page" in {
-        redirectLocation(result) shouldBe Some("/calculate-your-capital-gains/non-resident/session-timeout")
+        redirectLocation(result).get should include ("/calculate-your-capital-gains/session-timeout")
       }
     }
   }

--- a/test/controllers/resident/DeductionsControllerTests/AllowableLossesValueActionSpec.scala
+++ b/test/controllers/resident/DeductionsControllerTests/AllowableLossesValueActionSpec.scala
@@ -111,7 +111,7 @@ class AllowableLossesValueActionSpec extends UnitSpec with WithFakeApplication w
       }
 
       "return you to the session timeout page" in {
-        redirectLocation(result) shouldBe Some("/calculate-your-capital-gains/non-resident/session-timeout")
+        redirectLocation(result).get should include ("/calculate-your-capital-gains/session-timeout")
       }
     }
   }

--- a/test/controllers/resident/DeductionsControllerTests/AnnualExemptAmountActionSpec.scala
+++ b/test/controllers/resident/DeductionsControllerTests/AnnualExemptAmountActionSpec.scala
@@ -126,7 +126,7 @@ class AnnualExemptAmountActionSpec extends UnitSpec with WithFakeApplication wit
       }
 
       "return you to the session timeout page" in {
-        redirectLocation(result) shouldBe Some("/calculate-your-capital-gains/non-resident/session-timeout")
+        redirectLocation(result).get should include ("/calculate-your-capital-gains/session-timeout")
       }
     }
   }

--- a/test/controllers/resident/DeductionsControllerTests/LossesBroughtForwardValueActionSpec.scala
+++ b/test/controllers/resident/DeductionsControllerTests/LossesBroughtForwardValueActionSpec.scala
@@ -102,7 +102,7 @@ class LossesBroughtForwardValueActionSpec extends UnitSpec with WithFakeApplicat
       }
 
       "return you to the session timeout page" in {
-        redirectLocation(result) shouldBe Some("/calculate-your-capital-gains/non-resident/session-timeout")
+        redirectLocation(result).get should include ("/calculate-your-capital-gains/session-timeout")
       }
     }
   }

--- a/test/controllers/resident/DeductionsControllerTests/ReliefsActionSpec.scala
+++ b/test/controllers/resident/DeductionsControllerTests/ReliefsActionSpec.scala
@@ -100,7 +100,7 @@ class ReliefsActionSpec extends UnitSpec with WithFakeApplication with FakeReque
       }
 
       "return you to the session timeout page" in {
-        redirectLocation(result) shouldBe Some("/calculate-your-capital-gains/non-resident/session-timeout")
+        redirectLocation(result).get should include ("/calculate-your-capital-gains/session-timeout")
       }
     }
   }

--- a/test/controllers/resident/DeductionsControllerTests/ReliefsValueActionSpec.scala
+++ b/test/controllers/resident/DeductionsControllerTests/ReliefsValueActionSpec.scala
@@ -98,7 +98,7 @@ class ReliefsValueActionSpec extends UnitSpec with WithFakeApplication with Fake
     }
 
     "return you to the session timeout page" in {
-      redirectLocation(result) shouldBe Some("/calculate-your-capital-gains/non-resident/session-timeout")
+      redirectLocation(result).get should include ("/calculate-your-capital-gains/session-timeout")
     }
   }
 

--- a/test/controllers/resident/GainControllerTests/AcquisitionCostsActionSpec.scala
+++ b/test/controllers/resident/GainControllerTests/AcquisitionCostsActionSpec.scala
@@ -97,7 +97,7 @@ class AcquisitionCostsActionSpec extends UnitSpec with WithFakeApplication with 
     }
 
     "return you to the session timeout page" in {
-      redirectLocation(result) shouldBe Some("/calculate-your-capital-gains/non-resident/session-timeout")
+      redirectLocation(result).get should include ("/calculate-your-capital-gains/session-timeout")
     }
   }
 

--- a/test/controllers/resident/GainControllerTests/AcquisitionValueActionSpec.scala
+++ b/test/controllers/resident/GainControllerTests/AcquisitionValueActionSpec.scala
@@ -97,7 +97,7 @@ class AcquisitionValueActionSpec extends UnitSpec with WithFakeApplication with 
     }
 
     "return you to the session timeout view" in {
-      redirectLocation(result).get shouldBe "/calculate-your-capital-gains/non-resident/session-timeout"
+      redirectLocation(result).get should include ("/calculate-your-capital-gains/session-timeout")
     }
   }
 

--- a/test/controllers/resident/GainControllerTests/DisposalCostsActionSpec.scala
+++ b/test/controllers/resident/GainControllerTests/DisposalCostsActionSpec.scala
@@ -95,7 +95,7 @@ class DisposalCostsActionSpec extends UnitSpec with WithFakeApplication with Fak
     }
 
     "return you to the session timeout view" in {
-      redirectLocation(result).get shouldBe "/calculate-your-capital-gains/non-resident/session-timeout"
+      redirectLocation(result).get should include ("/calculate-your-capital-gains/session-timeout")
     }
   }
 

--- a/test/controllers/resident/GainControllerTests/ImprovementsActionSpec.scala
+++ b/test/controllers/resident/GainControllerTests/ImprovementsActionSpec.scala
@@ -105,7 +105,7 @@ class ImprovementsActionSpec extends UnitSpec with WithFakeApplication with Fake
     }
 
     "return you to the session timeout page" in {
-      redirectLocation(result) shouldBe Some("/calculate-your-capital-gains/non-resident/session-timeout")
+      redirectLocation(result).get should include ("/calculate-your-capital-gains/session-timeout")
     }
   }
 

--- a/test/controllers/resident/GainControllerTests/OutsideTaxYearsActionSpec.scala
+++ b/test/controllers/resident/GainControllerTests/OutsideTaxYearsActionSpec.scala
@@ -72,7 +72,7 @@ class OutsideTaxYearsActionSpec extends UnitSpec with WithFakeApplication with F
       }
 
       "return you to the session timeout page" in {
-        redirectLocation(result) shouldBe Some("/calculate-your-capital-gains/non-resident/session-timeout")
+        redirectLocation(result).get should include ("/calculate-your-capital-gains/session-timeout")
       }
     }
   }

--- a/test/controllers/resident/IncomeControllerSpec/CurrentIncomeActionSpec.scala
+++ b/test/controllers/resident/IncomeControllerSpec/CurrentIncomeActionSpec.scala
@@ -222,7 +222,7 @@ class CurrentIncomeActionSpec extends UnitSpec with WithFakeApplication with Fak
     }
 
     "return you to the session timeout view" in {
-      redirectLocation(result).get shouldBe "/calculate-your-capital-gains/non-resident/session-timeout"
+      redirectLocation(result).get should include ("/calculate-your-capital-gains/session-timeout")
     }
   }
 

--- a/test/controllers/resident/IncomeControllerSpec/PersonalAllowanceActionSpec.scala
+++ b/test/controllers/resident/IncomeControllerSpec/PersonalAllowanceActionSpec.scala
@@ -123,7 +123,7 @@ class PersonalAllowanceActionSpec extends UnitSpec with WithFakeApplication with
     }
 
     "return you to the session timeout page" in {
-      redirectLocation(result) shouldBe Some("/calculate-your-capital-gains/non-resident/session-timeout")
+      redirectLocation(result).get should include ("/calculate-your-capital-gains/session-timeout")
     }
   }
 

--- a/test/controllers/resident/IncomeControllerSpec/PreviousTaxableGainsActionSpec.scala
+++ b/test/controllers/resident/IncomeControllerSpec/PreviousTaxableGainsActionSpec.scala
@@ -165,7 +165,7 @@ class PreviousTaxableGainsActionSpec extends UnitSpec with WithFakeApplication w
     }
 
     "return you to the session timeout page" in {
-      redirectLocation(result) shouldBe Some("/calculate-your-capital-gains/non-resident/session-timeout")
+      redirectLocation(result).get should include ("/calculate-your-capital-gains/session-timeout")
     }
   }
 

--- a/test/controllers/resident/SummaryActionSpec.scala
+++ b/test/controllers/resident/SummaryActionSpec.scala
@@ -324,7 +324,7 @@ class SummaryActionSpec extends UnitSpec with WithFakeApplication with FakeReque
     }
 
     "return you to the session timeout view" in {
-      redirectLocation(result).get shouldBe "/calculate-your-capital-gains/non-resident/session-timeout"
+      redirectLocation(result).get should include ("/calculate-your-capital-gains/session-timeout")
     }
   }
 }


### PR DESCRIPTION
**Change Description**
To implement this change the FeatureLock and ValidActiveSession predicate traits have both been amended. 

FeatureLock has a val featureEnabled which is only set to true from its default position of false if the ApplicationConfig is set to true. 

This is achieved by overriding the val in the FeatureLockForRTT Object which extends the trait. This removed the need for an internal class called FeatureLockFor. The removal of this was required so that the Object could also override the val sessionTimeoutUrl in ValidActiveSession trait - see below.

There is now an additional val in the ValidActitveSession trait called sessionTimourUrl which is overridden by the Object which extends the trait. This allows each FeatureLock object to override with a specific journey start URL.

For the existing non-resident code the controller overrides the sessionTimeoutUrl as we have not implemented any feature locks within that controller.

This implementation hopefully allows for simplified scaling for further features which have different journey start points (urls).

**Note**
Moved the session-timeout route to be "calculate-your-capital-gains/session-timeout" rather than "calculate-your-capital-gains/non-resident/session-timeout"

This initially caused issues and required both the Assets routes and Feedback routes to be moved to app.Routes as well.