### PR TITLE
CGT-1495: Copied outsideTaxYear controller action, routes and tests

### DIFF
--- a/app/common/KeystoreKeys.scala
+++ b/app/common/KeystoreKeys.scala
@@ -62,4 +62,8 @@ object KeystoreKeys {
     val personalAllowance = "res:property:personalAllowance"
   }
 
+  object ResidentSharesKeys {
+    val disposalDate = "res:shares:disposalDate"
+  }
+
 }

--- a/app/config/ApplicationConfig.scala
+++ b/app/config/ApplicationConfig.scala
@@ -28,6 +28,7 @@ trait AppConfig {
   val reportAProblemPartialUrl: String
   val reportAProblemNonJSUrl: String
   val featureRTTEnabled: Boolean
+  val featureRTTSharesEnabled: Boolean
 }
 
 object ApplicationConfig extends AppConfig with ServicesConfig {
@@ -38,7 +39,8 @@ object ApplicationConfig extends AppConfig with ServicesConfig {
   private val contactFrontendService = baseUrl("contact-frontend")
   private val contactHost = configuration.getString(s"$env.microservice.services.contact-frontend.host").getOrElse("")
 
-  override lazy val featureRTTEnabled = getFeature(s"$env.features.RTT")
+  override lazy val featureRTTEnabled = getFeature(s"$env.features.RTT.properties")
+  override lazy val featureRTTSharesEnabled = getFeature(s"$env.features.RTT.shares")
 
   override lazy val assetsPrefix = loadConfig(s"assets.url") + loadConfig(s"assets.version")
   override lazy val analyticsToken = loadConfig(s"google-analytics.token")

--- a/app/config/frontendGlobal.scala
+++ b/app/config/frontendGlobal.scala
@@ -47,8 +47,19 @@ object FrontendGlobal
     super.onLoadConfig(config, path, classloader, mode)
   }
 
-  override def standardErrorTemplate(pageTitle: String, heading: String, message: String)(implicit rh: Request[_]): Html =
-    views.html.error_template(pageTitle, heading, message)
+  override def standardErrorTemplate(pageTitle: String, heading: String, message: String)(implicit rh: Request[_]): Html = {
+    val url = """^(.*[\/])""".r findFirstIn rh.path
+    val homeNavLink = url match {
+      case Some(path) if path == "/calculate-your-capital-gains/resident/properties/" =>
+        controllers.resident.properties.routes.GainController.disposalDate().url
+      case Some(path) if path == "/calculate-your-capital-gains/resident/shares/" =>
+        controllers.resident.shares.routes.GainController.disposalDate().url
+      case Some(path) if path == "/calculate-your-capital-gains/non-resident/" =>
+        controllers.nonresident.routes.CalculationController.customerType().url
+      case _ => "/calculate-your-capital-gains/"
+    }
+    views.html.error_template(pageTitle, heading, message, homeNavLink)
+  }
 
   override def microserviceMetricsConfig(implicit app: Application): Option[Configuration] = app.configuration.getConfig(s"microservice.metrics")
 }

--- a/app/controllers/predicates/FeatureLock.scala
+++ b/app/controllers/predicates/FeatureLock.scala
@@ -53,4 +53,9 @@ trait FeatureLock extends ValidActiveSession {
     override val featureEnabled = ApplicationConfig.featureRTTEnabled
     override val sessionTimeoutUrl = controllers.resident.properties.routes.GainController.disposalDate().url
   }
+
+  object FeatureLockForRTTShares extends FeatureLock {
+    override val featureEnabled = ApplicationConfig.featureRTTSharesEnabled
+    override val sessionTimeoutUrl = controllers.resident.shares.routes.GainController.disposalDate().url
+  }
 }

--- a/app/controllers/resident/properties/GainController.scala
+++ b/app/controllers/resident/properties/GainController.scala
@@ -81,7 +81,13 @@ trait GainController extends FeatureLock {
     for {
       disposalDate <- calcConnector.fetchAndGetFormData[DisposalDateModel](keystoreKeys.disposalDate)
       taxYear <- calcConnector.getTaxYear(s"${disposalDate.get.year}-${disposalDate.get.month}-${disposalDate.get.day}")
-    } yield {Ok(commonViews.outsideTaxYear(taxYear.get))}
+    } yield {
+      Ok(commonViews.outsideTaxYear(
+        taxYear = taxYear.get,
+        navHomeLink = routes.GainController.disposalDate().url,
+        continueUrl = routes.GainController.disposalValue().url
+      ))
+    }
   }
 
   //################ Disposal Value Actions ######################

--- a/app/controllers/resident/shares/GainController.scala
+++ b/app/controllers/resident/shares/GainController.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.resident.shares
+
+import common.KeystoreKeys.{ResidentSharesKeys => keystoreKeys}
+import connectors.CalculatorConnector
+import controllers.predicates.FeatureLock
+import views.html.calculation.{resident => commonViews}
+import models.resident._
+
+object GainController extends GainController {
+  val calcConnector = CalculatorConnector
+}
+
+trait GainController extends FeatureLock {
+
+  val calcConnector: CalculatorConnector
+
+  //################ Disposal Date Actions ######################
+  val disposalDate = TODO
+
+  //################ Outside Tax Years Actions ######################
+  val outsideTaxYears = FeatureLockForRTTShares.async { implicit request =>
+    for {
+      disposalDate <- calcConnector.fetchAndGetFormData[DisposalDateModel](keystoreKeys.disposalDate)
+      taxYear <- calcConnector.getTaxYear(s"${disposalDate.get.year}-${disposalDate.get.month}-${disposalDate.get.day}")
+    } yield {
+        Ok(commonViews.outsideTaxYear(
+            taxYear = taxYear.get,
+            navHomeLink = routes.GainController.disposalDate().url,
+            continueUrl = routes.GainController.disposalValue().url
+        ))
+    }
+  }
+
+  //################ Disposal Value Actions ######################
+  val disposalValue = TODO
+
+}

--- a/app/controllers/resident/shares/GainController.scala
+++ b/app/controllers/resident/shares/GainController.scala
@@ -37,7 +37,7 @@ trait GainController extends FeatureLock {
   val calcConnector: CalculatorConnector
 
   //################# Disposal Date Actions ####################
-  val disposalDate = FeatureLockForRTT.asyncNoTimeout { implicit request =>
+  val disposalDate = FeatureLockForRTTShares.asyncNoTimeout { implicit request =>
     if (request.session.get(SessionKeys.sessionId).isEmpty) {
       val sessionId = UUID.randomUUID.toString
       Future.successful(Ok(views.disposalDate(disposalDateForm)).withSession(request.session + (SessionKeys.sessionId -> s"session-$sessionId")))

--- a/app/views/calculation/resident/allowableLosses.scala.html
+++ b/app/views/calculation/resident/allowableLosses.scala.html
@@ -5,7 +5,12 @@
 
 @(allowableLossesForm: Form[AllowableLossesModel], taxYear: TaxYearModel)(implicit request: Request[_])
 
-@resident_main_template(title = Messages("calc.resident.allowableLosses.title", taxYear.taxYearSupplied), backLink = Some(controllers.resident.properties.routes.DeductionsController.otherProperties.toString())) {
+@resident_main_template(
+    title = Messages("calc.resident.allowableLosses.title",
+    taxYear.taxYearSupplied),
+    backLink = Some(controllers.resident.properties.routes.DeductionsController.otherProperties.toString()),
+    homeLink = "TODO - needs parameter"
+) {
 
     @errorSummary(allowableLossesForm, "isClaiming")
 

--- a/app/views/calculation/resident/allowableLossesValue.scala.html
+++ b/app/views/calculation/resident/allowableLossesValue.scala.html
@@ -7,7 +7,8 @@
 
 @resident_main_template(
     title = Messages("calc.resident.allowableLossesValue.title", taxYear.taxYearSupplied),
-    backLink = Some(controllers.resident.properties.routes.DeductionsController.allowableLosses().toString)
+    backLink = Some(controllers.resident.properties.routes.DeductionsController.allowableLosses().toString),
+    homeLink = "TODO - needs parameter"
 ){
 
     @errorSummary(allowableLossesValueForm, "amount")

--- a/app/views/calculation/resident/annualExemptAmount.scala.html
+++ b/app/views/calculation/resident/annualExemptAmount.scala.html
@@ -16,7 +16,12 @@
 </a>
 }
 
-@resident_main_template(title = Messages("calc.resident.annualExemptAmount.title"), backLink = Some(controllers.resident.properties.routes.DeductionsController.lossesBroughtForward().toString), sidebarLinks = Some(sidebar)) {
+@resident_main_template(
+    title = Messages("calc.resident.annualExemptAmount.title"),
+    backLink = Some(controllers.resident.properties.routes.DeductionsController.lossesBroughtForward().toString),
+    sidebarLinks = Some(sidebar),
+    homeLink = "TODO - needs parameter"
+) {
 
     @errorSummary(annualExemptAmountForm, "amount")
 

--- a/app/views/calculation/resident/lossesBroughtForward.scala.html
+++ b/app/views/calculation/resident/lossesBroughtForward.scala.html
@@ -5,7 +5,12 @@
 
 @(lossesBroughtForwardForm : Form[LossesBroughtForwardModel], backLinkUrl : String, taxYear: TaxYearModel)(implicit request: Request[_])
 
-@resident_main_template(title = Messages("calc.resident.lossesBroughtForward.title", taxYear.taxYearSupplied), backLink = Some(backLinkUrl)) {
+@resident_main_template(
+    title = Messages("calc.resident.lossesBroughtForward.title",
+    taxYear.taxYearSupplied),
+    backLink = Some(backLinkUrl),
+    homeLink = "TODO - needs parameter"
+) {
 
     @errorSummary(lossesBroughtForwardForm, "option")
 

--- a/app/views/calculation/resident/lossesBroughtForwardValue.scala.html
+++ b/app/views/calculation/resident/lossesBroughtForwardValue.scala.html
@@ -5,7 +5,12 @@
 
 @(lossesBroughtForwardValueForm: Form[LossesBroughtForwardValueModel], taxYear: TaxYearModel)(implicit request: Request[_])
 
-@resident_main_template(title = Messages("calc.resident.lossesBroughtForwardValue.title", taxYear.taxYearSupplied), backLink = Some(controllers.resident.properties.routes.DeductionsController.lossesBroughtForward.toString)) {
+@resident_main_template(
+    title = Messages("calc.resident.lossesBroughtForwardValue.title",
+    taxYear.taxYearSupplied),
+    backLink = Some(controllers.resident.properties.routes.DeductionsController.lossesBroughtForward.toString),
+    homeLink = "TODO - needs parameter"
+) {
 
     @errorSummary(lossesBroughtForwardValueForm, "losses-brought-forward-value")
 

--- a/app/views/calculation/resident/outsideTaxYear.scala.html
+++ b/app/views/calculation/resident/outsideTaxYear.scala.html
@@ -3,14 +3,18 @@
 @import views.html.calculation.resident._
 @import models.resident._
 
-@(taxYear: TaxYearModel)(implicit request: Request[_])
+@(taxYear: TaxYearModel, navHomeLink: String, continueUrl: String)(implicit request: Request[_])
 
-@resident_main_template(Messages("calc.resident.outsideTaxYears.title"), backLink = Some(controllers.resident.properties.routes.GainController.disposalDate().toString)) {
+@resident_main_template(
+    Messages("calc.resident.outsideTaxYears.title"),
+    backLink = Some(controllers.resident.properties.routes.GainController.disposalDate().toString),
+    homeLink = navHomeLink
+) {
 
     <h1 class="heading-large">@Messages("calc.resident.outsideTaxYears.title")</h1>
 
     <p class="lede">@Messages("calc.resident.outsideTaxYears.message", taxYear.calculationTaxYear)</p>
 
-    <a href="@controllers.resident.properties.routes.GainController.disposalValue.toString()" id="continue-button" class="button">@Messages("calc.base.button.continue")</a>
+    <a href="@continueUrl" id="continue-button" class="button">@Messages("calc.base.button.continue")</a>
 
 }

--- a/app/views/calculation/resident/personalAllowance.scala.html
+++ b/app/views/calculation/resident/personalAllowance.scala.html
@@ -20,7 +20,10 @@
 
 @resident_main_template(title = {if(taxYear.taxYearSupplied == "2016/17") {Messages("calc.resident.personalAllowance.currentYearTitle")}
     else {Messages("calc.resident.personalAllowance.title", taxYear.taxYearSupplied)}},
-    backLink = Some(controllers.resident.properties.routes.IncomeController.currentIncome().toString), sidebarLinks = Some(sidebar)) {
+    backLink = Some(controllers.resident.properties.routes.IncomeController.currentIncome().toString),
+    sidebarLinks = Some(sidebar),
+    homeLink = "TODO - needs parameter"
+) {
 
 @errorSummary(personalAllowanceForm, "amount")
 

--- a/app/views/calculation/resident/previousTaxableGains.scala.html
+++ b/app/views/calculation/resident/previousTaxableGains.scala.html
@@ -12,7 +12,11 @@
     </a>
 }
 
-@resident_main_template(Messages("calc.resident.previousTaxableGains.title"), backLink = Some(backUrl), sidebarLinks = Some(sidebar)) {
+@resident_main_template(
+    Messages("calc.resident.previousTaxableGains.title"),
+    backLink = Some(backUrl), sidebarLinks = Some(sidebar),
+    homeLink = "TODO - needs parameter"
+) {
 
     @errorSummary(previousTaxableGainsForm, "previousTaxableGains")
 

--- a/app/views/calculation/resident/properties/deductions/otherProperties.scala.html
+++ b/app/views/calculation/resident/properties/deductions/otherProperties.scala.html
@@ -1,7 +1,7 @@
 @import uk.gov.hmrc.play.views.html.helpers.form
 @import models.resident._
 @import views.html.helpers._
-@import views.html.calculation.resident._
+@import views.html.calculation.resident.properties._
 
 @(otherPropertiesForm: Form[OtherPropertiesModel], backUrl: String, taxYear: TaxYearModel)(implicit request: Request[_])
 
@@ -14,7 +14,7 @@
     </ul>
 }
 
-@resident_main_template(Messages("calc.resident.otherProperties.title", taxYear.taxYearSupplied), backLink = Some(backUrl)) {
+@resident_properties_main_template(Messages("calc.resident.otherProperties.title", taxYear.taxYearSupplied), backLink = Some(backUrl)) {
 
     @errorSummary(otherPropertiesForm, "hasOtherProperties")
 

--- a/app/views/calculation/resident/properties/deductions/reliefs.scala.html
+++ b/app/views/calculation/resident/properties/deductions/reliefs.scala.html
@@ -2,11 +2,11 @@
 @import views.html.helpers._
 @import models.resident.ReliefsModel
 @import uk.gov.hmrc.play.views.helpers.MoneyPounds
-@import views.html.calculation.resident._
+@import views.html.calculation.resident.properties._
 
 @(reliefsForm: Form[ReliefsModel], totalGain: BigDecimal)(implicit request: Request[_])
 
-@resident_main_template(title = Messages("calc.resident.reliefs.title", MoneyPounds(totalGain, 0).quantity), backLink = Some(controllers.resident.properties.routes.GainController.improvements.toString())) {
+@resident_properties_main_template(title = Messages("calc.resident.reliefs.title", MoneyPounds(totalGain, 0).quantity), backLink = Some(controllers.resident.properties.routes.GainController.improvements.toString())) {
 
     @errorSummary(reliefsForm, "reliefs")
 

--- a/app/views/calculation/resident/properties/deductions/reliefsValue.scala.html
+++ b/app/views/calculation/resident/properties/deductions/reliefsValue.scala.html
@@ -1,11 +1,11 @@
 @import models.resident.ReliefsValueModel
 @import uk.gov.hmrc.play.views.html.helpers.form
 @import views.html.helpers._
-@import views.html.calculation.resident._
+@import views.html.calculation.resident.properties._
 
 @(reliefsValueForm : Form[ReliefsValueModel])(implicit request: Request[_])
 
-@resident_main_template(title = Messages("calc.resident.reliefsValue.title"), backLink = Some(controllers.resident.properties.routes.DeductionsController.reliefs().toString)) {
+@resident_properties_main_template(title = Messages("calc.resident.reliefsValue.title"), backLink = Some(controllers.resident.properties.routes.DeductionsController.reliefs().toString)) {
 
     @errorSummary(reliefsValueForm, "reliefs-value")
 

--- a/app/views/calculation/resident/properties/gain/acquisitionCosts.scala.html
+++ b/app/views/calculation/resident/properties/gain/acquisitionCosts.scala.html
@@ -1,11 +1,11 @@
 @import uk.gov.hmrc.play.views.html.helpers.form
 @import models.resident.AcquisitionCostsModel
 @import views.html.helpers._
-@import views.html.calculation.resident._
+@import views.html.calculation.resident.properties._
 
 @(acquisitionCostsForm: Form[AcquisitionCostsModel])(implicit request: Request[_])
 
-@resident_main_template(Messages("calc.resident.acquisitionCosts.title"), backLink = Some(controllers.resident.properties.routes.GainController.acquisitionValue().toString)) {
+@resident_properties_main_template(Messages("calc.resident.acquisitionCosts.title"), backLink = Some(controllers.resident.properties.routes.GainController.acquisitionValue().toString)) {
 
     @errorSummary(acquisitionCostsForm, "amount")
 

--- a/app/views/calculation/resident/properties/gain/acquisitionValue.scala.html
+++ b/app/views/calculation/resident/properties/gain/acquisitionValue.scala.html
@@ -1,7 +1,7 @@
 @import uk.gov.hmrc.play.views.html.helpers.form
 @import models.resident.AcquisitionValueModel
 @import views.html.helpers._
-@import views.html.calculation.resident._
+@import views.html.calculation.resident.properties._
 
 @(acquisitionValueForm: Form[AcquisitionValueModel])(implicit request: Request[_])
 
@@ -25,7 +25,7 @@
     <p id="bullet-list-end">@Messages("calc.resident.acquisitionValue.bullet.end")</p>
 }
 
-@resident_main_template(Messages("calc.resident.acquisitionValue.title"), backLink = Some(controllers.resident.properties.routes.GainController.disposalCosts().toString)) {
+@resident_properties_main_template(Messages("calc.resident.acquisitionValue.title"), backLink = Some(controllers.resident.properties.routes.GainController.disposalCosts().toString)) {
 
     @errorSummary(acquisitionValueForm, "amount")
 

--- a/app/views/calculation/resident/properties/gain/disposalCosts.scala.html
+++ b/app/views/calculation/resident/properties/gain/disposalCosts.scala.html
@@ -1,11 +1,11 @@
 @import models.resident.DisposalCostsModel
 @import uk.gov.hmrc.play.views.html.helpers.form
 @import views.html.helpers._
-@import views.html.calculation.resident._
+@import views.html.calculation.resident.properties._
 
 @(disposalCostsForm: Form[DisposalCostsModel])(implicit request: Request[_])
 
-@resident_main_template(Messages("calc.resident.disposalCosts.title"), backLink = Some(controllers.resident.properties.routes.GainController.disposalValue().toString)) {
+@resident_properties_main_template(Messages("calc.resident.disposalCosts.title"), backLink = Some(controllers.resident.properties.routes.GainController.disposalValue().toString)) {
 
     @errorSummary(disposalCostsForm, "disposal-costs")
 

--- a/app/views/calculation/resident/properties/gain/disposalDate.scala.html
+++ b/app/views/calculation/resident/properties/gain/disposalDate.scala.html
@@ -1,11 +1,11 @@
 @import models.resident.DisposalDateModel
 @import uk.gov.hmrc.play.views.html.helpers.form
 @import views.html.helpers._
-@import views.html.calculation.resident._
+@import views.html.calculation.resident.properties._
 
 @(disposalDateForm: Form[DisposalDateModel])(implicit request: Request[_])
 
-@resident_main_template(Messages("calc.resident.disposalDate.question")){
+@resident_properties_main_template(Messages("calc.resident.disposalDate.question")){
 
     @errorSummary(disposalDateForm, "disposal-date", "disposalDateDay")
 

--- a/app/views/calculation/resident/properties/gain/disposalValue.scala.html
+++ b/app/views/calculation/resident/properties/gain/disposalValue.scala.html
@@ -1,7 +1,7 @@
 @import models.resident.DisposalValueModel
 @import uk.gov.hmrc.play.views.html.helpers.form
 @import views.html.helpers._
-@import views.html.calculation.resident._
+@import views.html.calculation.resident.properties._
 
 @(disposalValueForm : Form[DisposalValueModel])(implicit request: Request[_])
 
@@ -23,7 +23,7 @@
     <p id="bullet-list-end">@Messages("calc.resident.disposal.value.bullet.end")</p>
 }
 
-@resident_main_template(title = Messages("calc.resident.disposal.value.title"), backLink = Some(controllers.resident.properties.routes.GainController.disposalDate().toString)) {
+@resident_properties_main_template(title = Messages("calc.resident.disposal.value.title"), backLink = Some(controllers.resident.properties.routes.GainController.disposalDate().toString)) {
 
     @errorSummary(disposalValueForm, "amount")
 

--- a/app/views/calculation/resident/properties/gain/improvements.scala.html
+++ b/app/views/calculation/resident/properties/gain/improvements.scala.html
@@ -1,7 +1,7 @@
 @import models.resident.ImprovementsModel
 @import uk.gov.hmrc.play.views.html.helpers.form
 @import views.html.helpers._
-@import views.html.calculation.resident._
+@import views.html.calculation.resident.properties._
 
 @(improvementsForm : Form[ImprovementsModel])(implicit request: Request[_])
 
@@ -11,7 +11,7 @@
     </div>
 }
 
-@resident_main_template(title = Messages("calc.resident.improvements.title"), backLink = Some(controllers.resident.properties.routes.GainController.acquisitionCosts().toString)) {
+@resident_properties_main_template(title = Messages("calc.resident.improvements.title"), backLink = Some(controllers.resident.properties.routes.GainController.acquisitionCosts().toString)) {
 
     @errorSummary(improvementsForm, "improvements")
 

--- a/app/views/calculation/resident/properties/income/currentIncome.scala.html
+++ b/app/views/calculation/resident/properties/income/currentIncome.scala.html
@@ -1,4 +1,4 @@
-@import views.html.calculation.resident._
+@import views.html.calculation.resident.properties._
 @import models.resident.income.CurrentIncomeModel
 @import models.resident._
 @import uk.gov.hmrc.play.views.html.helpers.form
@@ -6,7 +6,7 @@
 
 @(currentIncomeForm: Form[CurrentIncomeModel], backUrl: String, taxYear: TaxYearModel)(implicit request: Request[_])
 
-@resident_main_template(if(taxYear.taxYearSupplied == "2016/17") {Messages("calc.resident.currentIncome.questionCurrentYear")
+@resident_properties_main_template(if(taxYear.taxYearSupplied == "2016/17") {Messages("calc.resident.currentIncome.questionCurrentYear")
                         } else {Messages("calc.resident.currentIncome.question", taxYear.taxYearSupplied)}, backLink = Some(backUrl)) {
 
     @errorSummary(currentIncomeForm, "current-income")

--- a/app/views/calculation/resident/properties/resident_properties_main_template.scala.html
+++ b/app/views/calculation/resident/properties/resident_properties_main_template.scala.html
@@ -6,8 +6,7 @@
   mainClass: Option[String] = None,
   scriptElem: Option[Html] = None,
   articleLayout: Boolean = true,
-  backLink: Option[String] = None,
-  homeLink: String
+  backLink: Option[String] = None
 )(mainContent: Html)(implicit request : Request[_])
 
 @import uk.gov.hmrc.play.views.html.layouts
@@ -52,6 +51,6 @@
                mainContent = contentLayout,
                serviceInfoContent = serviceInfoContent,
                scriptElem = scriptElem,
-               homeLink = homeLink
+               homeLink = controllers.resident.properties.routes.GainController.disposalDate().url
 )
 

--- a/app/views/calculation/resident/properties/summary/deductionsSummary.scala.html
+++ b/app/views/calculation/resident/properties/summary/deductionsSummary.scala.html
@@ -7,11 +7,11 @@
 @import controllers.resident.properties.routes.{GainController => gainRoutes}
 @import controllers.resident.properties.routes.{DeductionsController => deductionRoutes}
 @import uk.gov.hmrc.play.views.helpers.MoneyPounds
-@import views.html.calculation.resident._
+@import views.html.calculation.resident.properties._
 
 @(gainAnswers: YourAnswersSummaryModel, deductionAnswers: ChargeableGainAnswers, result: ChargeableGainResultModel, backUrl: String, taxYear: TaxYearModel)(implicit request: Request[_])
 
-@resident_main_template(
+@resident_properties_main_template(
 title = Messages("calc.resident.summary.title"),
 backLink = Some(backUrl),
 articleLayout = false

--- a/app/views/calculation/resident/properties/summary/finalSummary.scala.html
+++ b/app/views/calculation/resident/properties/summary/finalSummary.scala.html
@@ -1,5 +1,5 @@
 @import views.html.helpers.resident._
-@import views.html.calculation.resident._
+@import views.html.calculation.resident.properties._
 @import models.SummaryDataItemModel
 @import models.resident._
 @import common.Dates._
@@ -12,7 +12,7 @@
 
 @(gainAnswers: YourAnswersSummaryModel, deductionAnswers: ChargeableGainAnswers, incomeAnswers: IncomeAnswersModel, result: TotalGainAndTaxOwedModel, backUrl: String, taxYear: TaxYearModel)(implicit request: Request[_])
 
-@resident_main_template(
+@resident_properties_main_template(
 title = Messages("calc.resident.summary.title"),
 backLink = Some(backUrl),
 articleLayout = false

--- a/app/views/calculation/resident/properties/summary/gainSummary.scala.html
+++ b/app/views/calculation/resident/properties/summary/gainSummary.scala.html
@@ -4,11 +4,11 @@
 @import common.Dates._
 @import constructors.resident.SummaryConstructor._
 @import controllers.resident.properties.routes.{GainController => routes}
-@import views.html.calculation.resident._
+@import views.html.calculation.resident.properties._
 
 @(answers: YourAnswersSummaryModel, gain: BigDecimal, taxYear: TaxYearModel)(implicit request: Request[_])
 
-@resident_main_template(
+@resident_properties_main_template(
     title = Messages("calc.resident.summary.title"),
     backLink = Some(controllers.resident.properties.routes.GainController.improvements().toString),
     articleLayout = false

--- a/app/views/error_template.scala.html
+++ b/app/views/error_template.scala.html
@@ -1,5 +1,5 @@
 @import config.ApplicationConfig
-@(pageTitle: String, heading: String, message: String)(implicit request: Request[_])
+@(pageTitle: String, heading: String, message: String, homeNavLink: String)(implicit request: Request[_])
 
 @contentHeader = {
   <h1>@heading</h1>
@@ -9,4 +9,4 @@
   <p>@message</p>
 }
 
-@govuk_wrapper(appConfig = ApplicationConfig, title = pageTitle, contentHeader = Some(contentHeader), mainContent = mainContent)
+@govuk_wrapper(appConfig = ApplicationConfig, title = pageTitle, contentHeader = Some(contentHeader), mainContent = mainContent, homeLink = homeNavLink)

--- a/app/views/govuk_wrapper.scala.html
+++ b/app/views/govuk_wrapper.scala.html
@@ -8,7 +8,9 @@
   contentHeader: Option[Html] = None,
   mainContent: Html = HtmlFormat.empty,
   serviceInfoContent: Html = HtmlFormat.empty,
-  scriptElem: Option[Html] = None)(implicit request: Request[_])
+  scriptElem: Option[Html] = None,
+  homeLink: String
+)(implicit request: Request[_])
 
 @import layouts.{govuk_template => hmrcGovUkTemplate}
 @import uk.gov.hmrc.play.views.html.{layouts => uiLayouts}
@@ -32,7 +34,7 @@
 }
 
 @headerNavLinks = {
-  <li><a id="homeNavHref" href="@controllers.nonresident.routes.CalculationController.customerType"
+  <li><a id="homeNavHref" href="@homeLink"
          data-journey-click="primary-navigation:Click:Home">Home</a></li>
 }
 

--- a/app/views/main_template.scala.html
+++ b/app/views/main_template.scala.html
@@ -40,6 +40,7 @@
                contentHeader = contentHeader,
                mainContent = contentLayout,
                serviceInfoContent = serviceInfoContent,
-               scriptElem = scriptElem
+               scriptElem = scriptElem,
+               homeLink = controllers.nonresident.routes.CalculationController.customerType().url
 )
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -39,7 +39,10 @@ Dev {
     }
   }
   features {
-    RTT = true
+    RTT {
+      properties = true
+      shares = true
+    }
   }
 }
 
@@ -63,7 +66,10 @@ Test {
     }
   }
   features {
-    RTT = true
+    RTT {
+      properties = true
+      shares = true
+    }
   }
 }
 

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -2,6 +2,7 @@
 ->         /calculate-your-capital-gains/                        app.Routes
 ->         /calculate-your-capital-gains/non-resident/           nr.Routes
 ->         /calculate-your-capital-gains/resident/properties/    resident_properties.Routes
+->         /calculate-your-capital-gains/resident/shares/        resident_shares.Routes
 ->         /                                                     health.Routes
 ->     	   /template                                             template.Routes
 

--- a/conf/resident_shares.routes
+++ b/conf/resident_shares.routes
@@ -1,4 +1,4 @@
-#Routes file for the resident properties routes.
+#Routes file for the resident shares routes.
 
 #Disposal Date Routes
 GET     /disposal-date                    controllers.resident.shares.GainController.disposalDate

--- a/conf/resident_shares.routes
+++ b/conf/resident_shares.routes
@@ -1,0 +1,10 @@
+#Routes file for the resident properties routes.
+
+#Disposal Date Routes
+GET     /disposal-date                    controllers.resident.shares.GainController.disposalDate
+
+#Outside Tax Years Routes
+GET     /outside-tax-years                controllers.resident.shares.GainController.outsideTaxYears
+
+#Disposal Value Routes
+GET     /disposal-value                    controllers.resident.shares.GainController.disposalValue

--- a/test/config/FrontendGlobalSpec.scala
+++ b/test/config/FrontendGlobalSpec.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import org.jsoup.Jsoup
+import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+import config.FrontendGlobal._
+import play.api.test.FakeRequest
+import uk.gov.hmrc.play.http.SessionKeys
+
+class FrontendGlobalSpec extends UnitSpec with WithFakeApplication {
+
+  //############# Tests for homeLink ##########################
+  "Rendering the error_template by causing an error" when {
+
+    "on the non-resident journey" should {
+
+      s"have a link to the non-resident start journey '${controllers.nonresident.routes.CalculationController.customerType().url}'" in {
+
+        val fakeRequest = FakeRequest("GET", "/calculate-your-capital-gains/non-resident/error").withSession(SessionKeys.sessionId -> "12345")
+        val result = standardErrorTemplate("test", "teat-heading", "test-message")(fakeRequest)
+        val doc = Jsoup.parse(result.body)
+
+        doc.getElementById("homeNavHref").attr("href") shouldBe controllers.nonresident.routes.CalculationController.customerType().url
+      }
+
+    }
+
+    "on the resident/properties journey" should {
+
+      s"have a link to the resident/properties start journey '${controllers.resident.properties.routes.GainController.disposalDate().url}'" in {
+
+        val fakeRequest = FakeRequest("GET", "/calculate-your-capital-gains/resident/properties/error").withSession(SessionKeys.sessionId -> "12345")
+        val result = standardErrorTemplate("test", "teat-heading", "test-message")(fakeRequest)
+        val doc = Jsoup.parse(result.body)
+
+        doc.getElementById("homeNavHref").attr("href") shouldBe controllers.resident.properties.routes.GainController.disposalDate().url
+      }
+
+    }
+
+    "on the resident/shares journey" should {
+
+      s"have a link to the resident/shares start journey '${controllers.resident.shares.routes.GainController.disposalDate().url}'" in {
+
+        val fakeRequest = FakeRequest("GET", "/calculate-your-capital-gains/resident/shares/banana").withSession(SessionKeys.sessionId -> "12345")
+        val result = standardErrorTemplate("test", "teat-heading", "test-message")(fakeRequest)
+        val doc = Jsoup.parse(result.body)
+
+        doc.getElementById("homeNavHref").attr("href") shouldBe controllers.resident.shares.routes.GainController.disposalDate().url
+      }
+
+    }
+
+    "on a journey which does not exist" should {
+
+      "have a link to the non-resident start journey" in {
+
+        val fakeRequest = FakeRequest("GET", "/calculate-your-capital-gains/error").withSession(SessionKeys.sessionId -> "12345")
+        val result = standardErrorTemplate("test", "teat-heading", "test-message")(fakeRequest)
+        val doc = Jsoup.parse(result.body)
+
+        doc.getElementById("homeNavHref").attr("href") shouldBe "/calculate-your-capital-gains/"
+      }
+
+    }
+  }
+}

--- a/test/controllers/FeedbackControllerSpec.scala
+++ b/test/controllers/FeedbackControllerSpec.scala
@@ -72,6 +72,7 @@ class FeedbackControllerSpec extends UnitSpec with MockitoSugar with WithFakeApp
       override val reportAProblemPartialUrl: String = ""
       override val contactFormServiceIdentifier: String = ""
       override val featureRTTEnabled = true
+      override val featureRTTSharesEnabled = true
     }
   }
 

--- a/test/controllers/resident/shares/GainControllerTests/OutsideTaxYearsActionSpec.scala
+++ b/test/controllers/resident/shares/GainControllerTests/OutsideTaxYearsActionSpec.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.resident.shares.GainControllerTests
+
+import assets.MessageLookup.{outsideTaxYears => messages}
+import connectors.CalculatorConnector
+import controllers.helpers.FakeRequestHelper
+import controllers.resident.shares.GainController
+import models.resident.{DisposalDateModel, TaxYearModel}
+import org.jsoup.Jsoup
+import org.mockito.Matchers
+import org.mockito.Mockito._
+import org.scalatest.mock.MockitoSugar
+import play.api.test.Helpers._
+import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+
+class OutsideTaxYearsActionSpec extends UnitSpec with WithFakeApplication with FakeRequestHelper with MockitoSugar{
+
+  def setupTarget(disposalDateModel: Option[DisposalDateModel], taxYearModel: Option[TaxYearModel]): GainController = {
+
+    val mockCalcConnector = mock[CalculatorConnector]
+
+    when(mockCalcConnector.fetchAndGetFormData[DisposalDateModel](Matchers.any())(Matchers.any(), Matchers.any()))
+      .thenReturn(disposalDateModel)
+
+    when(mockCalcConnector.getTaxYear(Matchers.any())(Matchers.any()))
+      .thenReturn(taxYearModel)
+
+    new GainController {
+      val calcConnector = mockCalcConnector
+    }
+  }
+
+  "Calling .outsideTaxYears from the reesident/shares GainCalculationController" when {
+
+    "there is a valid session" should {
+      lazy val target = setupTarget(Some(DisposalDateModel(10, 10, 2014)), Some(TaxYearModel("2014/15", false, "2015/16")))
+      lazy val result = target.outsideTaxYears(fakeRequestWithSession)
+
+      "return a 200" in {
+        status(result) shouldBe 200
+      }
+
+      "return some html" in {
+        contentType(result) shouldBe Some("text/html")
+      }
+
+      s"return a title of ${messages.title}" in {
+        Jsoup.parse(bodyOf(result)).title shouldBe messages.title
+      }
+    }
+
+    "there is no valid session" should {
+      lazy val result = GainController.outsideTaxYears(fakeRequest)
+
+      "return a 303" in {
+        status(result) shouldBe 303
+      }
+
+      "return you to the session timeout page" in {
+        redirectLocation(result).get should include ("/calculate-your-capital-gains/session-timeout")
+      }
+    }
+  }
+}

--- a/test/routes/properties/RoutesSpec.scala
+++ b/test/routes/properties/RoutesSpec.scala
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package routes
+package routes.properties
 
-import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 import org.scalatest._
+import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 
 class RoutesSpec extends UnitSpec with WithFakeApplication with Matchers {
 
@@ -38,6 +38,7 @@ class RoutesSpec extends UnitSpec with WithFakeApplication with Matchers {
   "The URL for the outside tax years Action" should {
     "be equal to /calculate-your-capital-gains/resident/properties/outside-tax-years" in {
       val path = controllers.resident.properties.routes.GainController.outsideTaxYears().toString
+      path shouldEqual "/calculate-your-capital-gains/resident/properties/outside-tax-years"
     }
   }
 

--- a/test/routes/shares/RoutesSpec.scala
+++ b/test/routes/shares/RoutesSpec.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package routes.shares
+
+import org.scalatest._
+import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+import controllers.resident.shares.routes._
+
+class RoutesSpec extends UnitSpec with WithFakeApplication with Matchers {
+
+  "The URL for the resident/shares outside tax years Action" should {
+    "be equal to /calculate-your-capital-gains/resident/shares/outside-tax-years" in {
+      val path = GainController.outsideTaxYears().url
+      path shouldEqual "/calculate-your-capital-gains/resident/shares/outside-tax-years"
+    }
+  }
+}

--- a/test/routes/shares/RoutesSpec.scala
+++ b/test/routes/shares/RoutesSpec.scala
@@ -29,14 +29,14 @@ class RoutesSpec extends UnitSpec with WithFakeApplication with Matchers {
     }
   }
 
-  "The URL for the disposal date Action" should {
+  "The URL for the resident/shares disposal date Action" should {
     "be equal to /calculate-your-capital-gains/resident/shares/disposal-date" in {
       val path = controllers.resident.shares.routes.GainController.disposalDate.toString()
       path shouldEqual "/calculate-your-capital-gains/resident/shares/disposal-date"
     }
   }
 
-  "The URL for the submit disposal date Action" should {
+  "The URL for the resident/shares submit disposal date Action" should {
     "be equal to /calculate-your-capital-gains/resident/shares/disposal-date" in {
       val path = controllers.resident.shares.routes.GainController.submitDisposalDate.toString()
       path shouldEqual "/calculate-your-capital-gains/resident/shares/disposal-date"

--- a/test/views/resident/OutsideTaxYearsViewSpec.scala
+++ b/test/views/resident/OutsideTaxYearsViewSpec.scala
@@ -30,7 +30,7 @@ class OutsideTaxYearsViewSpec extends UnitSpec with WithFakeApplication with Fak
 
     "using a disposal date before 2015/16" should {
       lazy val taxYear = TaxYearModel("2014/15", false, "2015/16")
-      lazy val view = views.outsideTaxYear(taxYear)(fakeRequestWithSession)
+      lazy val view = views.outsideTaxYear(taxYear, "home-link", "continue-link")(fakeRequestWithSession)
       lazy val doc = Jsoup.parse(view.body)
 
       "have charset UTF-8" in {
@@ -39,6 +39,10 @@ class OutsideTaxYearsViewSpec extends UnitSpec with WithFakeApplication with Fak
 
       s"return a title of ${messages.title}" in {
         doc.title shouldBe messages.title
+      }
+
+      "have a home link to 'home-link'" in {
+        doc.getElementById("homeNavHref").attr("href") shouldEqual "home-link"
       }
 
       s"have a heading of ${messages.title}" in {
@@ -72,15 +76,15 @@ class OutsideTaxYearsViewSpec extends UnitSpec with WithFakeApplication with Fak
           button.text() shouldBe commonMessages.calcBaseContinue
         }
 
-        s"have an href to ${controllers.resident.properties.routes.GainController.disposalValue().toString()}" in {
-          button.attr("href") shouldBe controllers.resident.properties.routes.GainController.disposalValue().toString()
+        s"have an href to 'continue-link'" in {
+          button.attr("href") shouldBe "continue-link"
         }
       }
     }
 
     "using a disposal date after 2016/17" should {
       lazy val taxYear = TaxYearModel("2017/18", false, "2016/17")
-      lazy val view = views.outsideTaxYear(taxYear)(fakeRequestWithSession)
+      lazy val view = views.outsideTaxYear(taxYear, "home-link", "continue-link")(fakeRequestWithSession)
       lazy val doc = Jsoup.parse(view.body)
 
       "have charset UTF-8" in {
@@ -122,8 +126,8 @@ class OutsideTaxYearsViewSpec extends UnitSpec with WithFakeApplication with Fak
           button.text() shouldBe commonMessages.calcBaseContinue
         }
 
-        s"have an href to ${controllers.resident.properties.routes.GainController.disposalValue().toString()}" in {
-          button.attr("href") shouldBe controllers.resident.properties.routes.GainController.disposalValue().toString()
+        s"have an href to 'continue-link'" in {
+          button.attr("href") shouldBe "continue-link"
         }
       }
     }


### PR DESCRIPTION
**Important**

All the existing shared views have been amended to use the new template - this meant that a homeLink parameter needs to be passed to them. For now, there is a string **"TODO - Needs Parameter"** - this will have to be replaced when future tasks are worked on!


**Notes**

- re-uses the existing view, which has been amended to accept two new parameters for homeLink and continue action.

- Includes 'Home' link changes for error pages - this is dynamically determined based on the URL path in the frontendGlobal config. New test class added for this.

- Includes new template resident_main_template to pass the home link based on the journey to the govUkWrapper. (replaces the previous template)

- New resident_properties_main_template that sets the homelink to be the start of the resident_properties journey.

- The existing main_template (used by NRCGT) has been changed to default to the start of the NRCGT route