### PR TITLE
Added aria functionality for help text below button content

### DIFF
--- a/app/views/calculation/resident/allowableLosses.scala.html
+++ b/app/views/calculation/resident/allowableLosses.scala.html
@@ -1,10 +1,22 @@
 @import uk.gov.hmrc.play.views.html.helpers.form
 @import views.html.helpers._
+@import views.html.helpers.resident._
 @import models.resident._
 @import views.html.calculation.resident._
 @import play.api.mvc.Call
 
 @(allowableLossesForm: Form[AllowableLossesModel], taxYear: TaxYearModel, postAction: Call, backLink: Option[String])(implicit request: Request[_])
+
+@hiddenHelpTextContent = {
+    <div id="helpInfo">
+        <p>@Messages("calc.resident.allowableLosses.helpInfo.subtitle")</p>
+        <ul class="list-bullet">
+            <li>@Messages("calc.resident.allowableLosses.helpInfo.point1")</li>
+            <li>@Messages("calc.resident.allowableLosses.helpInfo.point2")</li>
+            <li>@Messages("calc.resident.allowableLosses.helpInfo.point3")</li>
+        </ul>
+    </div>
+}
 
 @resident_main_template(
     title = Messages("calc.resident.allowableLosses.title",
@@ -28,20 +40,13 @@
             '_legendClass -> "visuallyhidden",
             '_labelAfter -> true,
             '_labelClass -> "block-label",
-            '_groupClass -> "inline form-group radio-list"
+            '_groupClass -> "inline form-group radio-list",
+            '_fieldsetAttributes -> "aria-details = help"
         )
 
         <input type="hidden" name="isClaiming" value="" />
         <button class="button yes-no-button" type="submit" id="continue-button">@Messages("calc.base.continue")</button>
     }
 
-    <div id="helpInfo">
-        <p>@Messages("calc.resident.allowableLosses.helpInfo.title")</p>
-        <p>@Messages("calc.resident.allowableLosses.helpInfo.subtitle")</p>
-        <ul class="list-bullet">
-            <li>@Messages("calc.resident.allowableLosses.helpInfo.point1")</li>
-            <li>@Messages("calc.resident.allowableLosses.helpInfo.point2")</li>
-            <li>@Messages("calc.resident.allowableLosses.helpInfo.point3")</li>
-        </ul>
-    </div>
+    @expandableHelpTextHelper(Messages("calc.resident.allowableLosses.helpInfo.title"), hiddenHelpTextContent)
 }

--- a/app/views/calculation/resident/properties/deductions/reliefs.scala.html
+++ b/app/views/calculation/resident/properties/deductions/reliefs.scala.html
@@ -1,10 +1,26 @@
 @import uk.gov.hmrc.play.views.html.helpers.form
 @import views.html.helpers._
+@import views.html.helpers.resident._
 @import models.resident.properties.ReliefsModel
 @import uk.gov.hmrc.play.views.helpers.MoneyPounds
 @import views.html.calculation.resident.properties._
 
 @(reliefsForm: Form[ReliefsModel], totalGain: BigDecimal)(implicit request: Request[_])
+
+@hiddenHelpTextContent = {
+    <p>@Messages("calc.resident.reliefs.additionalContent.one")</p>
+    <ul class="list-bullet">
+        <li>
+            <a target="_blank" href="https://www.gov.uk/tax-sell-home/absence-from-home">@Messages("calc.resident.reliefs.link.one")
+                <span class="visuallyhidden">@Messages("calc.base.externalLink")</span></a>
+        </li>
+        <li>
+            <a target="_blank" href="https://www.gov.uk/tax-sell-home/let-out-part-of-home">@Messages("calc.resident.reliefs.link.two")
+                <span class="visuallyhidden">@Messages("calc.base.externalLink")</span></a>
+        </li>
+    </ul>
+    <p>@Messages("calc.resident.reliefs.additionalContent.two")</p>
+}
 
 @resident_properties_main_template(title = Messages("calc.resident.reliefs.title", MoneyPounds(totalGain, 0).quantity), backLink = Some(controllers.resident.properties.routes.GainController.improvements.toString())) {
 
@@ -26,7 +42,8 @@
                 '_helpText -> Messages("calc.resident.reliefs.helpText"),
                 '_labelAfter -> true,
                 '_labelClass -> "block-label",
-                '_groupClass -> "inline"
+                '_groupClass -> "inline",
+                '_fieldsetAttributes -> "aria-details = help"
             )
         </div>
 
@@ -35,16 +52,5 @@
 
     }
 
-    <p>@Messages("calc.resident.reliefs.additionalContent.one")</p>
-    <ul class="list-bullet">
-        <li>
-            <a target="_blank" href="https://www.gov.uk/tax-sell-home/absence-from-home">@Messages("calc.resident.reliefs.link.one")
-                <span class="visuallyhidden">@Messages("calc.base.externalLink")</span></a>
-        </li>
-        <li>
-            <a target="_blank" href="https://www.gov.uk/tax-sell-home/let-out-part-of-home">@Messages("calc.resident.reliefs.link.two")
-                <span class="visuallyhidden">@Messages("calc.base.externalLink")</span></a>
-        </li>
-    </ul>
-    <p>@Messages("calc.resident.reliefs.additionalContent.two")</p>
+    @expandableHelpTextHelper(Messages("calc.resident.reliefs.helpButton"), hiddenHelpTextContent)
 }

--- a/app/views/helpers/resident/expandableHelpTextHelper.scala.html
+++ b/app/views/helpers/resident/expandableHelpTextHelper.scala.html
@@ -1,0 +1,10 @@
+@(helpTextTitle: String, content: Html)
+
+<details id="help" role="group">
+    <summary role="button" aria-controls="details-content-0">
+        <span class="summary" data-journey-click="help:reveal:@helpTextTitle">@helpTextTitle</span>
+    </summary>
+    <div class="panel-indent">
+        @content
+    </div>
+</details>

--- a/conf/messages
+++ b/conf/messages
@@ -382,6 +382,7 @@ calc.resident.reliefs.link.one = Private Residence Relief
 calc.resident.reliefs.link.two = Lettings Relief
 calc.resident.reliefs.additionalContent.two = Tax reliefs are different from your Capital Gains Tax Allowance and Personal Allowance.
 calc.resident.reliefs.errorSelect = Tell us if you want to claim any tax reliefs on your total gain of £{0}
+calc.resident.reliefs.helpButton = What are Capital Gains Tax reliefs?
 
 
 ## Reliefs Value messages

--- a/test/assets/MessageLookup.scala
+++ b/test/assets/MessageLookup.scala
@@ -146,6 +146,7 @@ object MessageLookup {
     val helpLinkTwo = "Lettings Relief"
     val helpTwo = "Tax reliefs are different from your Capital Gains Tax Allowance and Personal Allowance."
     def errorSelect(value: String) = s"Tell us if you want to claim any tax reliefs on your total gain of £$value"
+    val helpButton = "What are Capital Gains Tax reliefs?"
   }
 
   //Reliefs Value messages

--- a/test/views/resident/AllowableLossesViewSpec.scala
+++ b/test/views/resident/AllowableLossesViewSpec.scala
@@ -55,18 +55,22 @@ class AllowableLossesViewSpec extends UnitSpec with WithFakeApplication with Fak
       }
     }
 
+    "have a fieldset with aria-details attribute" in {
+      doc.select("fieldset").attr("aria-details") shouldBe "help"
+    }
+
+    s"have a drop down button with the text ${messages.helpInfoTitle}" in {
+      doc.body.getElementsByTag("summary").attr("role") shouldBe "button"
+      doc.body.getElementsByTag("summary").text shouldEqual messages.helpInfoTitle
+    }
+
     "have a hidden legend" in {
       val legend = doc.select("legend")
       legend.hasClass("visuallyhidden") shouldBe true
     }
 
-    "have the correct help info title" in {
-      val element = doc.select("#helpInfo > p:eq(0)")
-      element.text shouldBe messages.helpInfoTitle
-    }
-
     "have the correct help info subtitle" in {
-      val element = doc.select("#helpInfo > p:eq(1)")
+      val element = doc.select("#helpInfo > p")
       element.text shouldBe messages.helpInfoSubtitle
     }
 

--- a/test/views/resident/helpers/ExpandableHelpTextHelperSpec.scala
+++ b/test/views/resident/helpers/ExpandableHelpTextHelperSpec.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.resident.helpers
+
+import org.jsoup.Jsoup
+import play.twirl.api.Html
+import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+import views.html.helpers.resident.expandableHelpTextHelper
+
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class ExpandableHelpTextHelperSpec extends UnitSpec with WithFakeApplication{
+
+  val content = expandableHelpTextHelper("testQ", Html("someHtml"))
+  val doc = Jsoup.parse(content.body)
+
+  "Expandable Help Text Helper" should {
+
+    "have a details tag" which {
+
+      val details = doc.select("details#help")
+
+      "has the id 'help'" in {
+        details.attr("id") shouldBe "help"
+      }
+
+      "has the role of 'group'" in {
+        details.attr("role") shouldBe "group"
+      }
+    }
+
+    "have a header summary" which {
+
+      val summary = doc.select("summary")
+
+      "has the role 'button'" in {
+        summary.attr("role") shouldBe "button"
+      }
+
+      "has 'aria-controls' of 'details-content-0" in {
+        summary.attr("aria-controls") shouldBe "details-content-0"
+      }
+
+      "has span with a class of 'summary'" in {
+        summary.select("span").hasClass("summary") shouldBe true
+      }
+
+      "contains text 'testQ'" in {
+        summary.select("summary").text shouldBe "testQ"
+      }
+    }
+
+    "have hidden html" which {
+
+      val hiddenHtml = doc.select("div")
+
+      "has the class 'panel-indent'" in {
+        hiddenHtml.hasClass("panel-indent") shouldBe true
+      }
+
+      "contains additional html text" in {
+        hiddenHtml.text shouldBe "someHtml"
+      }
+
+    }
+  }
+}

--- a/test/views/resident/properties/deductions/ReliefsViewSpec.scala
+++ b/test/views/resident/properties/deductions/ReliefsViewSpec.scala
@@ -59,6 +59,10 @@ class ReliefsViewSpec extends UnitSpec with WithFakeApplication with FakeRequest
       doc.select("span.form-hint").text() shouldEqual messages.help
     }
 
+    "have a fieldset with aria-details attribute" in {
+      doc.select("fieldset").attr("aria-details") shouldBe "help"
+    }
+
     s"have an input field with id isClaiming-yes " in {
       doc.body.getElementById("isClaiming-yes").tagName() shouldEqual "input"
     }
@@ -69,6 +73,11 @@ class ReliefsViewSpec extends UnitSpec with WithFakeApplication with FakeRequest
 
     "have a continue button " in {
       doc.body.getElementById("continue-button").text shouldEqual MessageLookup.calcBaseContinue
+    }
+
+    s"have a drop down button with the text ${messages.helpButton}" in {
+      doc.body.getElementsByTag("summary").attr("role") shouldBe "button"
+      doc.body.getElementsByTag("summary").text shouldEqual messages.helpButton
     }
 
     s"have an additional line help line ${messages.helpOne}" in {


### PR DESCRIPTION
- Created new helper for resident views
- Added drop down help text button to allowable losses (for properties and shares) and reliefs (for properties) views

Its worth having a quick google on the Accessible Rich Internet Applications (ARIA) for html usage to understand the need for it