### PR TITLE
Fixed single line deductions breakdown elements on PDF

### DIFF
--- a/app/views/helpers/resident/summaryNumericRowHelper.scala.html
+++ b/app/views/helpers/resident/summaryNumericRowHelper.scala.html
@@ -3,7 +3,9 @@
 @(rowId: String, question: String, amount: BigDecimal, link: Option[String] = None, additionalContent: Option[Seq[(String, String)]] = None)
 
 @additionalDetails(additionalText: String, additionalAmount: String) = {
-    <span class="form-hint font-small">@additionalText &pound;@additionalAmount</span>
+    <div>
+        <span class="form-hint font-small">@additionalText &pound;@additionalAmount</span>
+    </div>
 }
 
 <div id="@rowId" class="grid-layout grid-layout--stacked form-group font-medium">


### PR DESCRIPTION
Deductions elements on PDF reports are now on separate lines - normal summary pages look no different