### PR TITLE
CGT-1932: Removed the additional content from Acquisition Value

### DIFF
--- a/app/views/calculation/resident/shares/gain/acquisitionValue.scala.html
+++ b/app/views/calculation/resident/shares/gain/acquisitionValue.scala.html
@@ -5,14 +5,6 @@
 
 @(acquisitionValueForm: Form[AcquisitionValueModel], navHomeLink: String)(implicit request: Request[_])
 
-@bulletContent = {
-    <p id="bullet-list-title">@Messages("calc.resident.shares.acquisitionValue.bulletListTitle") </p>
-    <ul class="list-bullet">
-        <li id="bullet-list-one">@Messages("calc.resident.shares.acquisitionValue.bulletListOne")</li>
-        <li id="bullet-list-two">@Messages("calc.resident.shares.acquisitionValue.bulletListTwo")</li>
-    </ul>
-}
-
 @resident_main_template(
     Messages("calc.resident.shares.acquisitionValue.question"),
     backLink = Some(controllers.resident.shares.routes.GainController.disposalCosts().toString),
@@ -26,7 +18,12 @@
 
     @form(action = controllers.resident.shares.routes.GainController.submitAcquisitionValue) {
 
-        @formInputMoney(acquisitionValueForm, "amount", Messages("calc.resident.shares.acquisitionValue.question"), additionalHTMLContent = Some(bulletContent.toString()), hideLabel = true)
+        @formInputMoney(
+            acquisitionValueForm,
+            "amount",
+            Messages("calc.resident.shares.acquisitionValue.question"),
+            hideLabel = true
+        )
 
         <button class="button" type="submit" id="continue-button">@Messages("calc.base.continue")</button>
     }

--- a/app/views/calculation/resident/shares/gain/resident_shares_main_template.scala.html
+++ b/app/views/calculation/resident/shares/gain/resident_shares_main_template.scala.html
@@ -51,6 +51,7 @@
                mainContent = contentLayout,
                serviceInfoContent = serviceInfoContent,
                scriptElem = scriptElem,
-               homeLink = controllers.resident.shares.routes.GainController.disposalDate().url
+               homeLink = controllers.resident.shares.routes.GainController.disposalDate().url,
+               navTitle = Messages("calc.base.resident.shares.home")
 )
 

--- a/test/views/resident/shares/gain/AcquisitionValueViewSpec.scala
+++ b/test/views/resident/shares/gain/AcquisitionValueViewSpec.scala
@@ -98,21 +98,6 @@ class AcquisitionValueViewSpec extends UnitSpec with WithFakeApplication with Fa
         }
       }
 
-      "has additional content that" should {
-
-        s"have a bullet point list title of ${messages.bulletListTitle}" in {
-          doc.select("div.indent p#bullet-list-title").text() shouldEqual messages.bulletListTitle
-        }
-
-        s"have a first bullet point of ${messages.bulletListOne}" in {
-          doc.select("div.indent li#bullet-list-one").text() shouldEqual messages.bulletListOne
-        }
-
-        s"have a second bullet point of ${messages.bulletListTwo}" in {
-          doc.select("div.indent li#bullet-list-two").text() shouldEqual messages.bulletListTwo
-        }
-      }
-
       "has a numeric input field that" should {
 
         lazy val input = doc.body.getElementsByTag("input")


### PR DESCRIPTION
**Note**
Also added a quick hotfix to pass the shares title correctly to the GovUK wrapper in the `resident_shares_main_template.scala.html`