### PR TITLE
CGT-1978: Fixed ordering of radio buttons on sell-or-give-away 

### DIFF
--- a/app/views/calculation/resident/properties/gain/sellOrGiveAway.scala.html
+++ b/app/views/calculation/resident/properties/gain/sellOrGiveAway.scala.html
@@ -6,35 +6,34 @@
 @(sellOrGiveAwayForm: Form[SellOrGiveAwayModel], backLink: Option[String], homeLink: String, postAction: Call)(implicit request: Request[_])
 
 
-@resident_main_template(
-    title = Messages("calc.resident.sellOrGiveAway.title"),
-    backLink = backLink,
-    homeLink = homeLink,
-    navTitle = Messages("calc.base.resident.properties.home")
+    @resident_main_template(
+        title = Messages("calc.resident.sellOrGiveAway.title"),
+        backLink = backLink,
+        homeLink = homeLink,
+        navTitle = Messages("calc.base.resident.properties.home")
     ) {
 
-    @errorSummary(sellOrGiveAwayForm, "givenAway")
+        @errorSummary(sellOrGiveAwayForm, "givenAway")
 
-    <h1 class="heading-large">@Messages("calc.resident.sellOrGiveAway.title")</h1>
+        <h1 class="heading-large">@Messages("calc.resident.sellOrGiveAway.title")</h1>
 
-    @form(action = postAction) {
+        @form(action = postAction) {
 
-        @formInputRadioGroup(
-            field = sellOrGiveAwayForm("givenAway"),
-            Seq(
-                "Given"->Messages("calc.resident.sellOrGiveAway.given"),
-                "Sold"->Messages("calc.resident.sellOrGiveAway.sold")),
-            '_legend -> Messages("calc.resident.sellOrGiveAway.title"),
-            '_legendID -> "option",
-            '_legendClass -> "visuallyhidden",
-            '_labelAfter -> true,
-            '_labelClass -> "block-label",
-            '_groupClass -> "form-group radio-list",
-            '_fieldsetAttributes -> "aria-details = help"
-        )
+            @formInputRadioGroup(
+                field = sellOrGiveAwayForm("givenAway"),
+                Seq(
+                    "Sold" -> Messages("calc.resident.sellOrGiveAway.sold"),
+                    "Given" -> Messages("calc.resident.sellOrGiveAway.given")),
+                '_legend -> Messages("calc.resident.sellOrGiveAway.title"),
+                '_legendID -> "option",
+                '_legendClass -> "visuallyhidden",
+                '_labelAfter -> true,
+                '_labelClass -> "block-label",
+                '_groupClass -> "form-group radio-list",
+                '_fieldsetAttributes -> "aria-details = help"
+            )
 
-        <input type="hidden" name="givenAway" value="" />
-        <button class="button yes-no-button" type="submit" id="continue-button">@Messages("calc.base.continue")</button>
-
+            <input type="hidden" name="givenAway" value="" />
+            <button class="button yes-no-button" type="submit" id="continue-button">@Messages("calc.base.continue")</button>
+        }
     }
-}

--- a/conf/resident_properties.routes
+++ b/conf/resident_properties.routes
@@ -13,9 +13,6 @@ GET     /outside-tax-years                controllers.resident.properties.GainCo
 GET     /sell-or-give-away                controllers.resident.properties.GainController.sellOrGiveAway
 POST    /sell-or-give-away                controllers.resident.properties.GainController.submitSellOrGiveAway
 
-#Sell for Less Routes
-GET     /sell-for-less                    controllers.resident.properties.GainController.sellForLess
-
 #Who Did You Give It To Routes
 GET     /who-did-you-give-it-to           controllers.resident.properties.GainController.whoDidYouGiveItTo
 POST    /who-did-you-give-it-to           controllers.resident.properties.GainController.submitWhoDidYouGiveItTo
@@ -57,7 +54,7 @@ POST    /how-became-owner                 controllers.resident.properties.GainCo
 
 #Worth On Routes
 GET     /market-value-on-31-march-1982    controllers.resident.properties.GainController.worthOn
-POST    /market-value-on-31-march-1982                         controllers.resident.properties.GainController.submitWorthOn
+POST    /market-value-on-31-march-1982    controllers.resident.properties.GainController.submitWorthOn
 
 #Bought For Less Than Worth Routes
 GET     /bought-for-less-than-worth       controllers.resident.properties.GainController.boughtForLessThanWorth


### PR DESCRIPTION
Also fixed routes file to removed duplicate routes and formatting